### PR TITLE
Fix DNS entries creation

### DIFF
--- a/controllers/cfapi_controller_rendered_resources.go
+++ b/controllers/cfapi_controller_rendered_resources.go
@@ -592,11 +592,18 @@ func (r *CFAPIReconciler) createDNSEntries(ctx context.Context, korifiAPI, appsD
 	}, &ingress)
 
 	if err != nil {
-		logger.Error(err, "error getting ingress hostname")
+		logger.Error(err, "error getting ingress service")
 		return err
 	}
 
 	hostname := ingress.Status.LoadBalancer.Ingress[0].Hostname
+
+	if hostname == "" {
+		logger.Error(err, "hostname not found in ingress service, will try to use IP")
+		hostname = ingress.Status.LoadBalancer.Ingress[0].IP
+	}
+
+	log.Log.Info("hostname to use for dns entries: " + hostname)
 
 	// create dns entries
 	vals := struct {


### PR DESCRIPTION
- hostname retrieved from ingress LoadBalancer service is used to create DNS entries; this works on AWS; however, on other IaaS providers (GCP, Azure, CCEE) the LoadBalancer services does not have hostname assigned; it has IP address assigned; the reconciler is fixed to handle this situation and work with whatever is assigned on the LoadBalancer service
