### PR TITLE
Fix installing latest btp operator on kind

### DIFF
--- a/development/run-kind.sh
+++ b/development/run-kind.sh
@@ -339,7 +339,7 @@ install_btp_operator() {
   echo " Installing the BTP Operator Module "
   echo "************************************************"
   kubectl apply -f https://github.com/kyma-project/btp-manager/releases/latest/download/btp-manager.yaml
-  kubectl apply -f https://github.com/kyma-project/btp-manager/releases/latest/download/btp-operator-default-cr.yaml -n kyma-system
+  kubectl apply -f https://github.com/kyma-project/btp-manager/releases/latest/download/btp-operator.yaml
 }
 
 main() {


### PR DESCRIPTION
With release 1.2.14 of the btp-operator kyma module, the operator
resource is put into `btp-operator.yaml`

