### PR TITLE
Bump and vendor Korifi

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,15 +30,13 @@ ARG BTP_SERVICE_BROKER_RELEASE_DIR
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -ldflags="-X 'main.buildVersion=${TAG_default_tag}'" -a -o manager main.go
 
 
-ENV VERSION_KORIFI=0.16.1
 ENV BTP_SERVICE_BROKER_RELEASE_DIR=${BTP_SERVICE_BROKER_RELEASE_DIR}
 
 COPY dependencies/kpack module-data/kpack/
 
 COPY dependencies/gateway-api module-data/gateway-api/
 
-WORKDIR /workspace/module-data/korifi
-RUN curl -OLf https://github.com/cloudfoundry/korifi/releases/download/v$VERSION_KORIFI/korifi-$VERSION_KORIFI.tgz
+COPY dependencies/korifi module-data/korifi-chart/
 
 WORKDIR /workspace/module-data/btp-service-broker
 COPY $BTP_SERVICE_BROKER_RELEASE_DIR/helm helm

--- a/controllers/cfapi_controller_rendered_resources.go
+++ b/controllers/cfapi_controller_rendered_resources.go
@@ -883,12 +883,7 @@ func getStatusFromSample(objectInstance *v1alpha1.CFAPI) v1alpha1.CFAPIStatus {
 func (r *CFAPIReconciler) deployKorifi(ctx context.Context, appsDomain, korifiAPIDomain, cfDomain, crDomain, uaaURL string) error {
 	logger := log.FromContext(ctx)
 
-	helmfile, err := findOneGlob("./module-data/korifi/korifi-*.tgz")
-	if err != nil {
-		logger.Error(err, "Failed to find korifi helm chart under dir module-data/korifi")
-		return err
-	}
-	chart, err := loader.Load(helmfile)
+	chart, err := loader.Load("./module-data/korifi-chart")
 	if err != nil {
 		logger.Error(err, "error loading korifi helm chart")
 		return err

--- a/dependencies/korifi/Chart.yaml
+++ b/dependencies/korifi/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: korifi
+description: A Helm chart to deploy all Korifi components
+type: application
+version: 0.16.1

--- a/dependencies/korifi/INSTALL.EKS.md
+++ b/dependencies/korifi/INSTALL.EKS.md
@@ -1,0 +1,303 @@
+> **Warning**
+> Make sure you are using the correct version of these instructions by using the link in the release notes for the version you're trying to install. If you're not sure, check our [latest release](https://github.com/cloudfoundry/korifi/releases/latest).
+
+# Installing Korifi on a New Amazon EKS Cluster
+
+This document integrates our [install instructions](./INSTALL.md) with specific tips to install Korifi on [Amazon EKS](https://aws.amazon.com/eks/) using [ECR](https://aws.amazon.com/ecr/).
+
+## Prerequisites
+
+On top of the [common prerequisites](./INSTALL.md#prerequisites), you will need:
+  * [`aws`](https://docs.aws.amazon.com/cli)
+  * [`eksctl`](https://github.com/weaveworks/eksctl)
+
+## Initial setup
+
+Make sure you have followed the [common initial setup](./INSTALL.md#initial-setup) first.
+
+The following environment variables will be needed throughout this guide:
+
+* `CLUSTER_NAME`: the name of the EKS cluster to create/use.
+* `AWS_REGION`: the desired AWS region.
+* `ACCOUNT_ID`: the 12-digit ID of your AWS account.
+
+Here are the example values we'll use in this guide:
+
+```sh
+CLUSTER_NAME="my-cluster"
+AWS_REGION="us-west-1"
+ACCOUNT_ID="$(aws sts get-caller-identity --query "Account" --output text)"
+```
+
+### Cluster creation
+
+Create the cluster with OIDC enabled (used for service account / role association and the EBS CSI addon):
+
+```sh
+eksctl create cluster \
+  --name "${CLUSTER_NAME}" \
+  --region "${AWS_REGION}" \
+  --with-oidc
+```
+
+Your kubeconfig will be updated to be targeting the new cluster when this command completes.
+
+### Install the EBS CSI addon
+
+Create the [EBS CSI](https://docs.aws.amazon.com/eks/latest/userguide/ebs-csi.html) addon to allow PVCs.
+
+First, set up the service account and role for the addon:
+
+```sh
+eksctl create iamserviceaccount \
+  --name ebs-csi-controller-sa \
+  --namespace kube-system \
+  --region "${AWS_REGION}" \
+  --cluster "${CLUSTER_NAME}" \
+  --attach-policy-arn arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy \
+  --approve \
+  --role-only \
+  --role-name AmazonEKS_EBS_CSI_DriverRole
+```
+
+Next, install the addon:
+
+```sh
+eksctl create addon \
+  --name aws-ebs-csi-driver \
+  --region "${AWS_REGION}" \
+  --cluster "${CLUSTER_NAME}" \
+  --service-account-role-arn "arn:aws:iam::${ACCOUNT_ID}:role/AmazonEKS_EBS_CSI_DriverRole"
+```
+
+### Setup IAM role for access to ECR
+
+The main difference when installing Korifi on EKS with ECR, as opposed to other container registries, is that ECR tokens issued by the AWS CLI expire in 12 hours.
+This means they are not a good option for storing in Kubernetes secrets for Korifi to use.
+Instead, we must grant the ECR push and pull permissions in an IAM role and allow that role to be associated with various service accounts used by Korifi and Kpack.
+
+The [AWS docs](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html)
+have more details about associating IAM roles with Kubernetes service accounts.
+
+First, create the ECR policy:
+
+```
+cat >ecr-policy.json <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ecr:BatchCheckLayerAvailability",
+        "ecr:BatchGetImage",
+        "ecr:CompleteLayerUpload",
+        "ecr:GetAuthorizationToken",
+        "ecr:GetDownloadUrlForLayer",
+        "ecr:InitiateLayerUpload",
+        "ecr:PutImage",
+        "ecr:UploadLayerPart",
+        "ecr:CreateRepository",
+        "ecr:ListImages",
+        "ecr:BatchDeleteImage"
+      ],
+      "Resource": "*"
+    }
+  ]
+}
+EOF
+aws iam create-policy \
+    --policy-name korifi-ecr-push-pull-policy \
+    --region "${AWS_REGION}" \
+    --policy-document file://ecr-policy.json
+rm ecr-policy.json
+```
+
+Next, define the trust relationships with the service accounts:
+
+```
+OIDC_PROVIDER="$(aws eks describe-cluster \
+  --name "${CLUSTER_NAME}" \
+  --region "${AWS_REGION}" \
+  --query "cluster.identity.oidc.issuer" \
+  --output text |
+  sed -e "s/^https:\/\///"
+)"
+cat >trust-relationships.json <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "arn:aws:iam::${ACCOUNT_ID}:oidc-provider/${OIDC_PROVIDER}"
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "StringLike": {
+          "${OIDC_PROVIDER}:aud": "sts.amazonaws.com",
+          "${OIDC_PROVIDER}:sub": [
+            "system:serviceaccount:kpack:controller",
+            "system:serviceaccount:korifi:korifi-api-system-serviceaccount",
+            "system:serviceaccount:korifi:korifi-controllers-controller-manager",
+            "system:serviceaccount:korifi:korifi-kpack-image-builder-controller-manager",
+            "system:serviceaccount:*:kpack-service-account"
+          ]
+        }
+      }
+    }
+  ]
+}
+EOF
+```
+
+Last, create the role and associate it with the trust-relationships and the ECR access policy:
+
+```
+aws iam create-role \
+  --role-name korifi-ecr-service-account-role \
+  --region "${AWS_REGION}" \
+  --description "allows korifi service accounts to access ECR" \
+  --assume-role-policy-document file://trust-relationships.json
+rm trust-relationships.json
+aws iam attach-role-policy \
+  --role-name korifi-ecr-service-account-role \
+  --region "${AWS_REGION}" \
+  --policy-arn=arn:aws:iam::${ACCOUNT_ID}:policy/korifi-ecr-push-pull-policy
+```
+
+You will need the role ARN for subsequent steps.
+
+```
+ECR_ROLE_ARN="$(aws iam get-role \
+  --role-name korifi-ecr-service-account-role \
+  --query "Role.Arn" \
+  --output text
+)"
+```
+
+### Setup admin user
+
+You must supply a user to be the Korifi admin user.
+It is not recommended to use a privileged user, such as the one that created the cluster.
+A plain IAM user with no permissions is sufficient.
+
+Create the user and extract the ARN, key and secret:
+
+```sh
+aws iam create-user \
+  --user-name "${CLUSTER_NAME}-cf-admin" \
+  --region "${AWS_REGION}"
+USER_ARN="$(aws iam get-user \
+  --user-name "${CLUSTER_NAME}-cf-admin" \
+  --region "${AWS_REGION}" \
+  --query "User.Arn" \
+  --output text
+)"
+aws iam create-access-key \
+  --user-name "${CLUSTER_NAME}-cf-admin" \
+  --region "${AWS_REGION}" > creds.json
+USER_ACCESS_KEY_ID="$(jq -r .AccessKey.AccessKeyId creds.json)"
+USER_SECRET_ACCESS_KEY="$(jq -r .AccessKey.SecretAccessKey creds.json)"
+```
+
+To identify this user to Kubernetes, modify the kube-system/aws-auth configmap using `eksctl`:
+
+```
+eksctl create iamidentitymapping \
+  --cluster "${CLUSTER_NAME}" \
+  --region "${AWS_REGION}" \
+  --arn "${USER_ARN}" \
+  --username "${ADMIN_USERNAME}"
+```
+
+### Create a Kpack builder ECR repository
+
+Ensure we have an ECR repository to store the Kpack builder images:
+
+```
+aws ecr create-repository \
+  --region "${AWS_REGION}" \
+  --repository-name "${CLUSTER_NAME}/kpack-builder"
+KPACK_BUILDER_REPO="$(aws ecr describe-repositories \
+  --region "${AWS_REGION}" \
+  --repository-names "${CLUSTER_NAME}/kpack-builder" \
+  --query "repositories[0].repositoryUri" \
+  --output text
+)"
+```
+
+The droplets and package repositories will be created on demand by Korifi, on a per-app basis.
+
+## Dependencies
+
+Follow the [common instructions](./INSTALL.md#dependencies).
+
+After installing the [Kpack dependency](INSTALL.md#kpack), run the following commands to associate the controller service account with the ECR access role:
+
+```sh
+kubectl -n kpack annotate serviceaccount controller eks.amazonaws.com/role-arn="${ECR_ROLE_ARN}"
+kubectl -n kpack rollout restart deployment kpack-controller
+```
+
+## Pre-install configuration
+
+### Namespace creation
+
+No changes here, follow the [common instructions](./INSTALL.md#namespace-creation).
+
+### Container registry credentials `Secret`
+
+Skip this section.
+
+## Install Korifi
+
+Use the following Helm command to install Korifi:
+
+```sh
+helm install korifi https://github.com/cloudfoundry/korifi/releases/download/v<VERSION>/korifi-<VERSION>.tgz \
+  --namespace="$KORIFI_NAMESPACE" \
+  --set=generateIngressCertificates=true \
+  --set=rootNamespace="${ROOT_NAMESPACE}" \
+  --set=adminUserName="${ADMIN_USERNAME}" \
+  --set=api.apiServer.url="api.${BASE_DOMAIN}" \
+  --set=defaultAppDomainName="apps.${BASE_DOMAIN}" \
+  --set=containerRepositoryPrefix="${ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/${CLUSTER_NAME}/" \
+  --set=containerRegistrySecrets={} \
+  --set=eksContainerRegistryRoleARN="${ECR_ROLE_ARN}" \
+  --set=kpackImageBuilder.builderRepository="${KPACK_BUILDER_REPO}" \
+  --set=networking.gatewayClassName="${GATEWAY_CLASS_NAME}" \
+  --wait
+```
+
+## Post-install Configuration
+
+### DNS
+
+Follow the [common instructions](./INSTALL.md#dns).
+
+## Test Korifi
+
+First, let's create a CLI profile for your Korifi admin user:
+
+```sh
+aws configure --profile "${CLUSTER_NAME}-cf-admin"
+```
+
+At the prompts, specify the Access Key ID and Secreat Access Key:
+
+```
+AWS Access Key ID [None]: (use $USER_ACCESS_KEY_ID)
+AWS Secret Access Key [None]: (use $USER_SECRET_ACCESS_KEY)
+Default region name [None]: (use $AWS_REGION)
+Default output format [None]: <enter>
+```
+
+Now, we'll need to make sure `kubectl` and `cf` use this newly created profile:
+
+```
+export AWS_PROFILE="${CLUSTER_NAME}-cf-admin"
+```
+
+You can now follow the [common instructions](./INSTALL.md#test-korifi).
+When running `cf login`, make sure you select the entry associated with your EKS cluster.

--- a/dependencies/korifi/INSTALL.kind.md
+++ b/dependencies/korifi/INSTALL.kind.md
@@ -1,0 +1,104 @@
+> **Warning**
+> Make sure you are using the correct version of these instructions by using the link in the release notes for the version you're trying to install. If you're not sure, check our [latest release](https://github.com/cloudfoundry/korifi/releases/latest).
+
+# Install Korifi on kind
+
+In order to install korifi on kind effortlessly we have prepared an installation job definition that you simply apply to your kind cluster. It will install korifi with reasonable defautls using a local docker registry (also running on your kind cluster).
+
+> **Warning**
+> The installer will deploy korifi with experimental features. To find out more please check out the `experimental` section of korifi's helm [values](./helm/korifi/values.yaml) file.
+
+## Cluster creation
+
+In order to access the Korifi API, we'll need to [expose the cluster ingress locally](https://kind.sigs.k8s.io/docs/user/ingress/). To do it, create your kind cluster using a command like this:
+
+```sh
+cat <<EOF | kind create cluster --name korifi --config=-
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+containerdConfigPatches:
+- |-
+  [plugins."io.containerd.grpc.v1.cri".registry]
+    [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
+      [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localregistry-docker-registry.default.svc.cluster.local:30050"]
+        endpoint = ["http://127.0.0.1:30050"]
+    [plugins."io.containerd.grpc.v1.cri".registry.configs]
+      [plugins."io.containerd.grpc.v1.cri".registry.configs."127.0.0.1:30050".tls]
+        insecure_skip_verify = true
+nodes:
+- role: control-plane
+  extraPortMappings:
+  - containerPort: 32080
+    hostPort: 80
+    protocol: TCP
+  - containerPort: 32443
+    hostPort: 443
+    protocol: TCP
+  - containerPort: 30050
+    hostPort: 30050
+    protocol: TCP
+EOF
+```
+
+## Install Korifi
+
+- Run the installer job:
+
+```sh
+kubectl apply -f https://github.com/cloudfoundry/korifi/releases/latest/download/install-korifi-kind.yaml
+```
+
+- If you want track the job progress, run:
+
+```sh
+kubectl -n korifi-installer logs --follow job/install-korifi
+```
+
+- **Optional** After the job is complete you can delete the `korifi-installer` namespace
+
+```sh
+kubectl delete namespace korifi-installer
+```
+
+## Test Korifi
+
+- Target the api:
+
+```sh
+cf api https://localhost --skip-ssl-validation
+```
+
+- Authenticate as the cf admin user:
+
+```sh
+cf auth kind-korifi
+```
+
+- Create and target an org and a space
+
+```sh
+cf create-org org && cf create-space -o org space && cf target -o org
+```
+
+- Push a buildpack app and access it:
+
+```sh
+make build-dorifi
+cf push dorifi -p tests/assets/dorifi
+curl -k https://dorifi.apps-127-0-0-1.nip.io
+```
+
+- Push a docker app and access it:
+
+```sh
+cf push nginx --docker-image nginxinc/nginx-unprivileged:1.23.2
+curl -k https://nginx.apps-127-0-0-1.nip.io
+```
+
+## Cleanup
+
+When you no longer need korifi you can delete the whole kind cluster via:
+
+```sh
+kind delete cluster --name korifi
+```

--- a/dependencies/korifi/INSTALL.md
+++ b/dependencies/korifi/INSTALL.md
@@ -1,0 +1,274 @@
+> **Warning**
+> Make sure you are using the correct version of these instructions by using the link in the release notes for the version you're trying to install. If you're not sure, check our [latest release](https://github.com/cloudfoundry/korifi/releases/latest).
+
+# Korifi installation guide
+
+The following lines will guide you through the process of deploying a [released version](https://github.com/cloudfoundry/korifi/releases) of [Korifi](https://github.com/cloudfoundry/korifi).
+
+## Prerequisites
+
+-   Tools:
+    -   [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl);
+    -   [cf](https://docs.cloudfoundry.org/cf-cli/install-go-cli.html) CLI version 8.5 or greater;
+    -   [Helm](https://helm.sh/docs/intro/install/).
+-   Resources:
+    -   Kubernetes cluster of one of the [upstream releases](https://kubernetes.io/releases/);
+    -   Container Registry on which you have write permissions.
+
+This document was tested on:
+
+-   [EKS](https://aws.amazon.com/eks/), using AWS' [Elastic Container Registry (ECR)](https://aws.amazon.com/ecr/) (see [_Install Korifi on EKS_](./INSTALL.EKS.md));
+-   [GKE](https://cloud.google.com/kubernetes-engine), using GCP's [Artifact Registry](https://cloud.google.com/artifact-registry);
+-   [kind](https://kind.sigs.k8s.io/): see [_Install Korifi on kind_](./INSTALL.kind.md).
+
+## Initial setup
+
+The following environment variables will be needed throughout this guide:
+
+-   `ROOT_NAMESPACE`: the namespace at the root of the Korifi org and space hierarchy. The default value is `cf`.
+-   `KORIFI_NAMESPACE`: the namespace in which Korifi will be installed.
+-   `ADMIN_USERNAME`: the name of the Kubernetes user who will have CF admin privileges on the Korifi installation. For security reasons, you should choose or create a user that is different from your cluster admin user. To provision new users, follow the user management instructions specific for your cluster's [authentication configuration](https://kubernetes.io/docs/reference/access-authn-authz/authentication/) or create a [new (short-lived) client certificate for user authentication](https://kubernetes.io/docs/reference/access-authn-authz/certificate-signing-requests/#normal-user).
+-   `BASE_DOMAIN`: the base domain used by both the Korifi API and, by default, all apps running on Korifi.
+-   `GATEWAY_CLASS_NAME`: the name of the Gateway API gatewayclass ([see contour section](#contour)).
+
+Here are the example values we'll use in this guide:
+
+```sh
+export ROOT_NAMESPACE="cf"
+export KORIFI_NAMESPACE="korifi"
+export ADMIN_USERNAME="cf-admin"
+export BASE_DOMAIN="korifi.example.org"
+export GATEWAY_CLASS_NAME="contour"
+```
+
+### Free Dockerhub accounts
+
+DockerHub allows only one private repository per free account. In case the DockerHub account you configure Korifi with has the `private` [default repository privacy](https://hub.docker.com/settings/default-privacy) enabled, then Korifi would only be able to create a single repository and would get `UNAUTHORIZED: authentication required` error when trying to push to a subsequent repository. This could either cause build errors during `cf push`, or the Kpack cluster builder may never become ready. Therefore you should either set the default repository privacy to `public`, or upgrade your DockerHub subscription plan. As of today, the `Pro` subscription plan provides unlimited private repositories.
+
+## Dependencies
+
+### Cert-Manager (optional)
+
+[Cert-Manager](https://cert-manager.io) allows us to automatically generate certificates within the cluster. It is required if you want Korifi to generate self-signed certificates for API and workload ingress or for internal use, like webhooks. In order to do this you have to set the `generateIngressCertificates` and/or `generateInternalCertificates` values to `true`. Follow the [instructions](https://cert-manager.io/docs/installation/) to install the latest version.
+
+### Kpack
+
+[Kpack](https://github.com/pivotal/kpack) is used to build runnable applications from source code using [Cloud Native Buildpacks](https://buildpacks.io/). Follow the [instructions](https://github.com/pivotal/kpack/blob/main/docs/install.md) to install the [latest version](https://github.com/pivotal/kpack/releases/latest).
+
+The Helm chart will create an example Kpack `ClusterBuilder` (with the associated `ClusterStore` and `ClusterStack`) by default. To use your own `ClusterBuilder`, specify the `kpackImageBuilder.clusterBuilderName` value. See the [Kpack documentation](https://github.com/pivotal/kpack/blob/main/docs/builders.md) for details on how to set up your own `ClusterBuilder`.
+
+### Contour
+
+[Contour](https://projectcontour.io/) is our [ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) controller. Contour implements the [Gateway API](https://gateway-api.sigs.k8s.io/). There are two ways to deploy Contour with Gateway API support: static provisioning and dynamic provisioning.
+
+#### Static Provisioning
+
+Follow the static provisioning [instructions](https://projectcontour.io/docs/1.26/config/gateway-api/#static-provisioning) from the Gateway API support guide to install the latest version. Note that as part of the Contour installation you have to create a gatewayclass with name `$GATEWAY_CLASS_NAME`:
+
+```bash
+kubectl apply -f - <<EOF
+kind: GatewayClass
+apiVersion: gateway.networking.k8s.io/v1beta1
+metadata:
+  name: $GATEWAY_CLASS_NAME
+spec:
+  controllerName: projectcontour.io/gateway-controller
+EOF
+```
+
+This gatewayclass name is a parameter of the helm chart installing korifi. The helm chart is going to define a gateway that will be used for all korifi ingress traffic.
+
+#### Dynamic Provisioning
+
+Follow the dynamic provisioning [instructions](https://projectcontour.io/docs/1.26/config/gateway-api/#dynamic-provisioning) from the Gateway API support guide to install the latest version.
+
+  - Note that as part of the Contour installation you have to create a gatewayclass with name `$GATEWAY_CLASS_NAME`:
+    ```bash
+    kubectl apply -f - <<EOF
+    kind: GatewayClass
+    apiVersion: gateway.networking.k8s.io/v1beta1
+    metadata:
+      name: $GATEWAY_CLASS_NAME
+    spec:
+      controllerName: projectcontour.io/gateway-controller
+    EOF
+    ```
+  - You DO NOT need to create a gateway as per the instructions. The Korifi helm chart defines a gateway that will be used for all korifi ingress traffic. The gateway will be created in the `korifi-gateway` namespace.
+
+### Metrics Server
+
+We use the [Kubernetes Metrics Server](https://github.com/kubernetes-sigs/metrics-server) to implement [process stats](https://v3-apidocs.cloudfoundry.org/#get-stats-for-a-process).
+Most Kubernetes distributions will come with `metrics-server` already installed. If yours does not, you should follow the [instructions](https://github.com/kubernetes-sigs/metrics-server#installation) to install it.
+
+## Pre-install configuration
+
+### Namespace creation
+
+Create the root and korifi namespaces:
+
+```sh
+cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: $ROOT_NAMESPACE
+  labels:
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/enforce: restricted
+EOF
+
+cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: $KORIFI_NAMESPACE
+  labels:
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/enforce: restricted
+EOF
+```
+
+### Container registry credentials `Secret`
+
+> **Warning**
+> This is not required when using ECR on an EKS deployment.
+
+Use the following command to create a `Secret` that Korifi and Kpack will use to connect to your container registry:
+
+```sh
+kubectl --namespace "$ROOT_NAMESPACE" create secret docker-registry image-registry-credentials \
+    --docker-username="<your-container-registry-username>" \
+    --docker-password="<your-container-registry-password>" \
+    --docker-server="<your-container-registry-hostname-and-port>"
+```
+
+Make sure the value of `--docker-server` is a valid [URI authority](https://datatracker.ietf.org/doc/html/rfc3986#section-3.2).
+
+-   If using **DockerHub**:
+    -   `--docker-server` should be omitted;
+    -   `--docker-username` should be your DockerHub user;
+    -   `--docker-password` can be either your DockerHub password or a [generated personal access token](https://hub.docker.com/settings/security?generateToken=true).
+-   If using **Google Artifact Registry**:
+    -   `--docker-server` should be `<region>-docker.pkg.dev`;
+    -   `--docker-username` should be `_json_key`;
+    -   `--docker-password` should be the JSON-formatted access token for a service account that has permission to manage images in Google Artifact Registry.
+
+### TLS certificates
+
+Korifi uses two kinds of TLS certificates:
+1. Ingress certificates: if `generateIngressCertificates` is set to `true`, Korifi will generate self-signed certificates and use them for API and workloads ingress.
+1. Internal certificates: if `generateInternalCertificates` is set to `true` (the default value), Korifi will generate self-signed certificates and use them for securing internal communication, like webhooks.
+
+A running cert-manager is a prerequisite for generating self-signed certificates.
+
+If you want to generate certificates yourself, set `generateIngressCertificates` and `generateInternalCertificates` to `false` and point to your own certificates using the following values:
+
+1. `api.apiServer.ingressCertSecret`: the name of the `Secret` in the `$KORIFI_NAMESPACE` namespace containing the API ingress certificate; defaults to `korifi-api-ingress-cert`.
+1. `api.apiServer.internalCertSecret`: the name of the `Secret` in the `$KORIFI_NAMESPACE` namespace containing a certificate that is valid for `korifi-api-svc.korifi.svc.cluster.local` (the internal dns of the korifi api); defaults to `korifi-api-internal-cert`.
+1. `controllers.workloadsTLSSecret`: the name of the `Secret` in the `$KORIFI_NAMESPACE` namespace containing the workload ingress certificate; defaults to `korifi-workloads-ingress-cert`.
+1. `controllers.webhookCertSecret`: the name of the `Secret` in the `$KORIFI_NAMESPACE` namespace containing the webhook certificate for the controllers deployment; defaults to `korifi-controllers-webhook-cert`.
+1. `kpackImageBuilder.webhookCertSecret`: the name of the `Secret` in the `$KORIFI_NAMESPACE` namespace containing the webhook certificate for the kpackImageBuilder deployment; defaults to `korifi-kpack-image-builder-webhook-cert`.
+1. `statefulsetRunner.webhookCertSecret`: the name of the `Secret` in the `$KORIFI_NAMESPACE` namespace containing the webhook certificate for the statefulsetRunner deployment; defaults to `korifi-statefulset-runner-webhook-cert`.
+
+
+### Container registry Certificate Authority
+
+Korifi can be configured to use a custom Certificate Authority when contacting the container registry. To do so, first create a `Secret` containing the CA certificate:
+
+```sh
+kubectl --namespace "$KORIFI_NAMESPACE" create secret generic <registry-ca-secret-name> \
+    --from-file=ca.crt=</path/to/ca-certificate>
+```
+
+You can then specify the `<registry-ca-secret-name>` using the `containerRegistryCACertSecret`.
+
+> **Warning**
+> Kpack does not support self-signed/internal CA configuration out of the box (see [pivotal/kpack#207](https://github.com/pivotal/kpack/issues/207)).
+> In order to make Kpack trust your CA certificate, you will have to inject it in both the Kpack controller and the Kpack build pods.
+> * The [`kpack-controller` `Deployment`](https://github.com/pivotal/kpack/blob/main/config/controller.yaml) can be modified to mount a `Secret` similar to the one created above: see the [Korifi API `Deployment`](https://github.com/cloudfoundry/korifi/blob/main/helm/korifi/api/deployment.yaml) for an example of how to do this.
+> * For the build pods you can use the [cert-injection-webhook](https://github.com/vmware-tanzu/cert-injection-webhook), configured on the `kpack.io/build` label.
+
+## Install Korifi
+
+Korifi is distributed as a [Helm chart](https://helm.sh). See [_Customizing the Chart Before Installing_](https://helm.sh/docs/intro/using_helm/#customizing-the-chart-before-installing) for details on how to specify values when installing a Helm chart.
+
+For example:
+
+```sh
+helm install korifi https://github.com/cloudfoundry/korifi/releases/download/v<VERSION>/korifi-<VERSION>.tgz \
+    --namespace="$KORIFI_NAMESPACE" \
+    --set=generateIngressCertificates=true \
+    --set=rootNamespace="$ROOT_NAMESPACE" \
+    --set=adminUserName="$ADMIN_USERNAME" \
+    --set=api.apiServer.url="api.$BASE_DOMAIN" \
+    --set=defaultAppDomainName="apps.$BASE_DOMAIN" \
+    --set=containerRepositoryPrefix=europe-docker.pkg.dev/my-project/korifi/ \
+    --set=kpackImageBuilder.builderRepository=europe-docker.pkg.dev/my-project/korifi/kpack-builder \
+    --set=networking.gatewayClass=$GATEWAY_CLASS_NAME \
+    --wait
+```
+
+`containerRepositoryPrefix` is used to determine the container repository for the package and droplet images produced by Korifi.
+In particular, the app GUID and image type (`packages` or `droplets`) are appended to form the name of the repository.
+For example:
+
+| Registry                          | containerRepositoryPrefix                                    | Resultant Image Ref                                                            | Notes                                                                                                    |
+| --------------------------------- | ------------------------------------------------------------ | ------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------- |
+| Azure Container Registry          | `<projectID>.azurecr.io/foo/bar/korifi-`                     | `<projectID>.azurecr.io/foo/bar/korifi-<appGUID>-packages`                     | Repositories are created dynamically during push by ACR                                                  |
+| DockerHub                         | `index.docker.io/<dockerOrganisation>/`                      | `index.docker.io/<dockerOrganisation>/<appGUID>-packages`                      | Docker does not support nested repositories                                                              |
+| Amazon Elastic Container Registry | `<projectID>.dkr.ecr.<region>.amazonaws.com/foo/bar/korifi-` | `<projectID>.dkr.ecr.<region>.amazonaws.com/foo/bar/korifi-<appGUID>-packages` | Korifi will create the repository before pushing, as dynamic repository creation is not posssible on ECR |
+| Google Artifact Registry          | `<region>-docker.pkg.dev/<projectID>/foo/bar/korifi-`        | `<region>-docker.pkg.dev/<projectID>/foo/bar/korifi-<appGUID>-packages`        | The `foo` repository must already exist in GAR                                                           |
+| Google Container Registry         | `gcr.io/<projectID>/foo/bar/korifi-`                         | `gcr.io/<projectID>/foo/bar/korifi-<appGUID>-packages`                         | Repositories are created dynamically during push by GCR                                                  |
+| GitHub Container Registry         | `ghcr.io/<githubUserName>/foo/bar/korifi-`                   | `ghcr.io/<githubUserName>/foo/bar/korifi-<appGUID>-package`                    | Repositories are created dynamically during push by GHCR                                                 |
+
+The chart provides various other values that can be set. See [`README.helm.md`](./README.helm.md) for details.
+
+### Configure an Authentication Proxy (optional)
+
+If you are using an authentication proxy with your cluster to enable SSO, you must set the following chart values:
+
+-   `api.authProxy.host`: IP address of your cluster's auth proxy;
+-   `api.authProxy.caCert`: CA certificate of your cluster's auth proxy.
+
+### Using a Custom Ingress Controller
+
+Korifi leverages the Gateway API for networking. This means that it should be easy to switch to any Gateway API compatible Ingress Controller implementation (e.g. Istio).
+
+## Post-install Configuration
+
+### DNS
+
+Create DNS entries for the Korifi API and for the apps running on Korifi. They should match the Helm values used to [deploy Korifi](#deploy-korifi):
+
+-   The Korifi API entry should match the `api.apiServer.url` value. In our example, that would be `api.korifi.example.org`.
+-   The apps entry should be a wildcard matching the `defaultAppDomainName` value. In our example, `*.apps.korifi.example.org`.
+
+The DNS entries should point to the load balancer endpoint created by Contour when installed.
+
+If you used static provisioning of a Contour gateway, discover your endpoint with:
+
+```sh
+kubectl get service envoy -n projectcontour -ojsonpath='{.status.loadBalancer.ingress[0]}'
+```
+
+If you used dynamic provisioning of a Contour gateway, discover your endpoint with:
+
+```sh
+kubectl get service envoy-korifi -n korifi-gateway -ojsonpath='{.status.loadBalancer.ingress[0]}'
+```
+
+It may take some time before the address is available. Retry this until you see a result.
+
+The type of DNS records to create will differ based on the type of the endpoint: `ip` endpoints (e.g. the ones created by GKE) will need an `A` record, while `hostname` endpoints (e.g. on EKS) a `CNAME` record.
+
+## Test Korifi
+
+```sh
+cf api https://api.$BASE_DOMAIN --skip-ssl-validation
+cf login # choose the entry in the list associated to $ADMIN_USERNAME
+cf create-org org1
+cf create-space -o org1 space1
+cf target -o org1
+cd <directory of a test cf app>
+cf push test-app
+```

--- a/dependencies/korifi/README.helm.md
+++ b/dependencies/korifi/README.helm.md
@@ -1,0 +1,157 @@
+# Korifi Helm chart
+
+This documents the [Helm](https://helm.sh/) chart for [Korifi](https://github.com/cloudfoundry/korifi).
+
+The configuration for each individual component is nested under a top-level key named after the component itself.
+Values at the top-level apply to all components.
+
+Each component can be excluded from the deployment by the setting its `include` value to `false`.
+See [_Customizing the Chart Before Installing_](https://helm.sh/docs/intro/using_helm/#customizing-the-chart-before-installing) for details on how to specify values when installing a Helm chart.
+
+Here are all the values that can be set for the chart:
+
+- `adminUserName` (_String_): Name of the admin user that will be bound to the Cloud Foundry Admin role.
+- `api`:
+  - `apiServer`:
+    - `ingressCertSecret` (_String_): The name of the secret containing the TLS certificate for the API ingress.
+    - `internalCertSecret` (_String_): The name of the secret containing the TLS certificate for internal api access. It needs to be valid for 'korifi-api-svc.korifi.svc.cluster.local'.
+    - `internalPort` (_Integer_): Port used internally by the API container.
+    - `port` (_Integer_): API external port. Defaults to `443`.
+    - `timeouts`: HTTP timeouts.
+      - `idle` (_Integer_): Idle timeout.
+      - `read` (_Integer_): Read timeout.
+      - `readHeader` (_Integer_): Read header timeout.
+      - `write` (_Integer_): Write timeout.
+    - `url` (_String_): API URL.
+  - `authProxy`: Needed if using a cluster authentication proxy, e.g. [Pinniped](https://pinniped.dev/).
+    - `caCert` (_String_): Proxy's PEM-encoded CA certificate (*not* as Base64).
+    - `host` (_String_): Must be a host string, a host:port pair, or a URL to the base of the apiserver.
+  - `image` (_String_): Reference to the API container image.
+  - `include` (_Boolean_): Deploy the API component.
+  - `infoConfig`: The /v3/info endpoint configuration.
+    - `custom`: `custom` attribute in the /v3/info endpoint
+    - `description` (_String_): `description` attribute in the /v3/info endpoint
+    - `minCLIVersion` (_String_): `minimum` CLI version attribute in the /v3/info endpoint
+    - `name` (_String_): `name` attribute in the /v3/info endpoint
+    - `recommendedCLIVersion` (_String_): `recommended` CLI version attribute in the /v3/info endpoint
+    - `supportAddress` (_String_): `support` attribute in the /v3/info endpoint
+  - `lifecycle`: Default lifecycle for apps.
+    - `stack` (_String_): Stack.
+    - `type` (_String_): Lifecycle type (only `buildpack` accepted currently).
+  - `list`: List behaviour configuration
+    - `defaultPageSize` (_Integer_): Page size in case 'per_page' query parameter is not provided in list queries
+  - `nodeSelector`: Node labels for korifi-api pod assignment.
+  - `replicas` (_Integer_): Number of replicas.
+  - `resources`: [`ResourceRequirements`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#resourcerequirements-v1-core) for the API.
+    - `limits`: Resource limits.
+      - `cpu` (_String_): CPU limit.
+      - `memory` (_String_): Memory limit.
+    - `requests`: Resource requests.
+      - `cpu` (_String_): CPU request.
+      - `memory` (_String_): Memory request.
+  - `tolerations` (_Array_): Korifi-api pod tolerations for taints.
+  - `userCertificateExpirationWarningDuration` (_String_): Issue a warning if the user certificate provided for login has a long expiry. See [`time.ParseDuration`](https://pkg.go.dev/time#ParseDuration) for details on the format.
+- `containerRegistrySecret` (_String_): Deprecated in favor of containerRegistrySecrets.
+- `containerRegistrySecrets` (_Array_): List of `Secret` names to use when pushing or pulling from package, droplet and kpack builder repositories. Required if eksContainerRegistryRoleARN not set. Ignored if eksContainerRegistryRoleARN is set.
+- `containerRepositoryPrefix` (_String_): The prefix of the container repository where package and droplet images will be pushed. This is suffixed with the app GUID and `-packages` or `-droplets`. For example, a value of `index.docker.io/korifi/` will result in `index.docker.io/korifi/<appGUID>-packages` and `index.docker.io/korifi/<appGUID>-droplets` being pushed.
+- `controllers`:
+  - `extraVCAPApplicationValues`: Key-value pairs that are going to be set in the VCAP_APPLICATION env var on apps. Nested values are not supported.
+  - `image` (_String_): Reference to the controllers container image.
+  - `maxRetainedBuildsPerApp` (_Integer_): How many staged builds to keep, excluding the app's current droplet. Older staged builds will be deleted, along with their corresponding container images.
+  - `maxRetainedPackagesPerApp` (_Integer_): How many 'ready' packages to keep, excluding the package associated with the app's current droplet. Older 'ready' packages will be deleted, along with their corresponding container images.
+  - `namespaceLabels`: Key-value pairs that are going to be set as labels on the namespaces created by Korifi.
+  - `nodeSelector`: Node labels for korifi-controllers pod assignment.
+  - `processDefaults`:
+    - `diskQuotaMB` (_Integer_): Default disk quota for the `web` process.
+    - `memoryMB` (_Integer_): Default memory limit for the `web` process.
+  - `replicas` (_Integer_): Number of replicas.
+  - `resources`: [`ResourceRequirements`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#resourcerequirements-v1-core) for the API.
+    - `limits`: Resource limits.
+      - `cpu` (_String_): CPU limit.
+      - `memory` (_String_): Memory limit.
+    - `requests`: Resource requests.
+      - `cpu` (_String_): CPU request.
+      - `memory` (_String_): Memory request.
+  - `taskTTL` (_String_): How long before the `CFTask` object is deleted after the task has completed. See [`time.ParseDuration`](https://pkg.go.dev/time#ParseDuration) for details on the format, an additional `d` suffix for days is supported.
+  - `tolerations` (_Array_): Korifi-controllers pod tolerations for taints.
+  - `webhookCertSecret` (_String_): A secert containing the CA bundle and the certificate for the webhook server.
+  - `workloadsTLSSecret` (_String_): TLS secret used when setting up an app routes.
+- `crds`:
+  - `include` (_Boolean_): Install CRDs as part of the Helm installation.
+- `debug` (_Boolean_): Enables remote debugging with [Delve](https://github.com/go-delve/delve).
+- `defaultAppDomainName` (_String_): Base domain name for application URLs.
+- `eksContainerRegistryRoleARN` (_String_): Amazon Resource Name (ARN) of the IAM role to use to access the ECR registry from an EKS deployed Korifi. Required if containerRegistrySecret not set.
+- `experimental`: Experimental features. No guarantees are provided and breaking/backwards incompatible changes should be expected. These features are not recommended for use in production environments.
+  - `api`:
+  - `externalLogCache`:
+    - `enabled` (_Boolean_): Enable external LogCache
+    - `trustInsecureLogCache` (_Boolean_): Disable external log cache certificate validation. Not recommended to be set to 'true' in production environments
+    - `url` (_String_): The url of the exernal LogCache server
+  - `managedServices`:
+    - `enabled` (_Boolean_): Enable managed services support
+    - `trustInsecureBrokers` (_Boolean_): Disable service broker certificate validation. Not recommended to be set to 'true' in production environments
+  - `routing`:
+    - `disableRouteController` (_Boolean_): Disable route controller. Default value is 'false'.
+  - `securityGroups`:
+    - `enabled` (_Boolean_): Enable security groups support
+  - `uaa`:
+    - `enabled` (_Boolean_): Enable UAA support
+    - `url` (_String_): The url of a UAA instance
+- `generateIngressCertificates` (_Boolean_): Use `cert-manager` to generate self-signed certificates for the API and app endpoints.
+- `generateInternalCertificates` (_Boolean_): Use `cert-manager` to generate internal self-signed certificates, e.g. for the webhooks.
+- `helm`:
+  - `hooksImage` (_String_): Image for the helm hooks containing kubectl
+- `jobTaskRunner`:
+  - `include` (_Boolean_): Deploy the `job-task-runner` component.
+  - `jobTTL` (_String_): How long before the `Job` backing up a task is deleted after completion. See [`time.ParseDuration`](https://pkg.go.dev/time#ParseDuration) for details on the format, an additional `d` suffix for days is supported.
+  - `replicas` (_Integer_): Number of replicas.
+  - `resources`: [`ResourceRequirements`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#resourcerequirements-v1-core) for the API.
+    - `limits`: Resource limits.
+      - `cpu` (_String_): CPU limit.
+      - `memory` (_String_): Memory limit.
+    - `requests`: Resource requests.
+      - `cpu` (_String_): CPU request.
+      - `memory` (_String_): Memory request.
+- `kpackImageBuilder`:
+  - `builderReadinessTimeout` (_String_): The time that the kpack Builder will be waited for if not in ready state, berfore the build workload fails. See [`time.ParseDuration`](https://pkg.go.dev/time#ParseDuration) for details on the format, an additional `d` suffix for days is supported.
+  - `builderRepository` (_String_): Container image repository to store the `ClusterBuilder` image. Required when `clusterBuilderName` is not provided.
+  - `clusterBuilderName` (_String_): The name of the `ClusterBuilder` Kpack has been configured with. Leave blank to let `kpack-image-builder` create an example `ClusterBuilder`.
+  - `include` (_Boolean_): Deploy the `kpack-image-builder` component.
+  - `replicas` (_Integer_): Number of replicas.
+  - `resources`: [`ResourceRequirements`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#resourcerequirements-v1-core) for the API.
+    - `limits`: Resource limits.
+      - `cpu` (_String_): CPU limit.
+      - `memory` (_String_): Memory limit.
+    - `requests`: Resource requests.
+      - `cpu` (_String_): CPU request.
+      - `memory` (_String_): Memory request.
+  - `webhookCertSecret` (_String_): A secert containing the CA bundle and the certificate for the webhook server.
+- `logLevel` (_String_): Sets level of logging for api and controllers components. Can be 'info' or 'debug'.
+- `migration`:
+  - `include` (_Boolean_): Deploy the migration component.
+- `networking`: Networking configuration
+  - `gatewayClass` (_String_): The name of the GatewayClass Korifi Gateway references
+  - `gatewayInfrastructure`: Optional GatewayInfrastructure property of the Gateway, see https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.GatewayInfrastructure for contents
+  - `gatewayPorts`: Ports for the Gateway listeners
+    - `http` (_Integer_): HTTP port
+    - `https` (_Integer_): HTTPS port
+- `reconcilers`:
+  - `app` (_String_): ID of the workload runner to set on all `AppWorkload` objects. Defaults to `statefulset-runner`.
+  - `build` (_String_): ID of the image builder to set on all `BuildWorkload` objects. Defaults to `kpack-image-builder`.
+- `rootNamespace` (_String_): Root of the Cloud Foundry namespace hierarchy.
+- `stagingRequirements`:
+  - `buildCacheMB` (_Integer_): Persistent disk in MB for caching staging artifacts across builds.
+  - `diskMB` (_Integer_): Ephemeral Disk request in MB for staging apps.
+  - `memoryMB` (_Integer_): Memory request in MB for staging.
+- `statefulsetRunner`:
+  - `include` (_Boolean_): Deploy the `statefulset-runner` component.
+  - `replicas` (_Integer_): Number of replicas.
+  - `resources`: [`ResourceRequirements`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#resourcerequirements-v1-core) for the API.
+    - `limits`: Resource limits.
+      - `cpu` (_String_): CPU limit.
+      - `memory` (_String_): Memory limit.
+    - `requests`: Resource requests.
+      - `cpu` (_String_): CPU request.
+      - `memory` (_String_): Memory request.
+  - `webhookCertSecret` (_String_): A secert containing the CA bundle and the certificate for the webhook server.
+- `systemImagePullSecrets` (_Array_): List of `Secret` names to be used when pulling Korifi system images from private registries

--- a/dependencies/korifi/README.md
+++ b/dependencies/korifi/README.md
@@ -1,0 +1,35 @@
+# Korifi Helm Chart
+Korifi is a kubernetes native implementation of the Cloud Foundry V3 API. For more information check out the [project on github](https://github.com/cloudfoundry/korifi)
+
+# Quick Start
+
+If you want to try out Korifi on your local machine we recommend [installing korifi on kind](https://github.com/cloudfoundry/korifi/blob/main/INSTALL.kind.md)
+
+# Installation
+
+1. Make sure [dependencies](https://github.com/cloudfoundry/korifi/blob/main/INSTALL.md#dependencies) are installed
+
+
+2. Add the korifi repository:
+
+```
+helm repo add korifi https://cloudfoundry.github.io/korifi/
+```
+
+3. Install the korifi helm chart
+
+```
+helm install my-korifi korifi/korifi
+    --create-namespace \
+    --namespace=korifi \
+    --set=generateIngressCertificates=true \
+    --set=adminUserName=cf-admin \
+    --set=api.apiServer.url="api.korifi.example.org" \
+    --set=defaultAppDomainName="apps.korifi.example.org" \
+    --set=containerRepositoryPrefix=index.docker.io/my-organization/ \
+    --set=kpackImageBuilder.builderRepository=index.docker.io/my-organization/kpack-builder \
+    --set=networking.gatewayClass=contour \
+    --wait
+```
+
+Refer to the [installation guide](https://github.com/cloudfoundry/korifi/blob/main/INSTALL.md) for more information on how to configure the helm values

--- a/dependencies/korifi/api/configmap.yaml
+++ b/dependencies/korifi/api/configmap.yaml
@@ -1,0 +1,119 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: korifi-api-config
+  namespace: {{ .Release.Namespace }}
+data:
+  korifi_api_config.yaml: |
+    externalFQDN: {{ .Values.api.apiServer.url }}
+    externalPort: {{ .Values.api.apiServer.port | default 443 }}
+    internalFQDN: korifi-api-svc.{{ .Release.Namespace }}.svc.cluster.local
+    internalPort: {{ .Values.api.apiServer.internalPort }}
+    idleTimeout: {{ .Values.api.apiServer.timeouts.idle }}
+    readTimeout: {{ .Values.api.apiServer.timeouts.read }}
+    readHeaderTimeout: {{ .Values.api.apiServer.timeouts.readHeader }}
+    writeTimeout: {{ .Values.api.apiServer.timeouts.write }}
+    infoConfig:
+      description: {{ .Values.api.infoConfig.description }}
+      name: {{ .Values.api.infoConfig.name }}
+      minCLIVersion: {{ .Values.api.infoConfig.minCLIVersion }}
+      recommendedCLIVersion: {{ .Values.api.infoConfig.recommendedCLIVersion }}
+    {{- with .Values.api.infoConfig.custom }}
+      custom:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      supportAddress: {{ .Values.api.infoConfig.supportAddress }}
+    rootNamespace: {{ .Values.rootNamespace }}
+    builderName: {{ .Values.reconcilers.build }}
+    runnerName: {{ .Values.reconcilers.run }}
+    defaultLifecycleConfig:
+      type: {{ .Values.api.lifecycle.type }}
+      stack: {{ .Values.api.lifecycle.stack }}
+      stagingMemoryMB: {{ .Values.stagingRequirements.memoryMB }}
+    containerRepositoryPrefix: {{ .Values.containerRepositoryPrefix | quote }}
+    {{- if not .Values.eksContainerRegistryRoleARN }}
+    {{- if .Values.containerRegistrySecrets }}
+    packageRegistrySecretNames:
+    {{- range .Values.containerRegistrySecrets }}
+    - {{ . | quote }}
+    {{- end }}
+    {{- else if .Values.containerRegistrySecret }}
+    packageRegistrySecretNames:
+    - {{ .Values.containerRegistrySecret | quote }}
+    {{- else }}
+    {{ required "containerRegistrySecrets is required when eksContainerRegistryRoleARN is not set" .Values.containerRegistrySecrets }}
+    {{- end }}
+    {{- end }}
+    defaultDomainName: {{ .Values.defaultAppDomainName }}
+    userCertificateExpirationWarningDuration: {{ .Values.api.userCertificateExpirationWarningDuration }}
+    {{- if .Values.api.authProxy }}
+    authProxyHost: {{ .Values.api.authProxy.host | quote }}
+    authProxyCACert: {{ .Values.api.authProxy.caCert | quote }}
+    {{- end }}
+    logLevel: {{ .Values.logLevel }}
+    {{- if .Values.eksContainerRegistryRoleARN }}
+    containerRegistryType: "ECR"
+    {{- end }}
+    list:
+      defaultPageSize: {{ .Values.api.list.defaultPageSize }}
+    experimental:
+      managedServices:
+        enabled: {{ .Values.experimental.managedServices.enabled }}
+      uaa:
+        enabled: {{ .Values.experimental.uaa.enabled }}
+        url: {{ .Values.experimental.uaa.url }}
+      externalLogCache:
+        enabled: {{ .Values.experimental.externalLogCache.enabled }}
+        url: {{ .Values.experimental.externalLogCache.url }}
+        trustInsecureLogCache: {{ .Values.experimental.externalLogCache.trustInsecureLogCache }}
+      k8sclient:
+        qps: {{ .Values.experimental.api.k8sclient.qps }}
+        burst: {{ .Values.experimental.api.k8sclient.burst }}
+      securityGroups:
+        enabled: {{ .Values.experimental.securityGroups.enabled }}
+  role_mappings_config.yaml: |
+    roleMappings:
+      admin:
+        name: korifi-controllers-admin
+        propagate: true
+      admin_read_only:
+        name: korifi-controllers-admin-read-only
+        propagate: true
+      cf_user:
+        name: korifi-controllers-root-namespace-user
+        propagate: false
+      global_auditor:
+        name: korifi-controllers-global-auditor
+        propagate: true
+      organization_auditor:
+        name: korifi-controllers-organization-auditor
+        level: org
+        propagate: false
+      organization_billing_manager:
+        name: korifi-controllers-organization-billing-manager
+        level: org
+        propagate: false
+      organization_manager:
+        name: korifi-controllers-organization-manager
+        level: org
+        propagate: true
+      organization_user:
+        name: korifi-controllers-organization-user
+        level: org
+        propagate: false
+      space_auditor:
+        name: korifi-controllers-space-auditor
+        level: space
+        propagate: false
+      space_developer:
+        name: korifi-controllers-space-developer
+        level: space
+        propagate: false
+      space_manager:
+        name: korifi-controllers-space-manager
+        level: space
+        propagate: false
+      space_supporter:
+        name: korifi-controllers-space-supporter
+        level: space
+        propagate: false

--- a/dependencies/korifi/api/deployment.yaml
+++ b/dependencies/korifi/api/deployment.yaml
@@ -1,0 +1,87 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: korifi-api
+  name: korifi-api-deployment
+  namespace: {{ .Release.Namespace }}
+spec:
+  replicas: {{ .Values.api.replicas | default 1}}
+  selector:
+    matchLabels:
+      app: korifi-api
+  template:
+    metadata:
+      labels:
+        app: korifi-api
+      annotations:
+        checksum/config: {{ tpl ($.Files.Get "api/configmap.yaml") $ | sha256sum }}
+    spec:
+      containers:
+      - env:
+        - name: APICONFIG
+          value: /etc/korifi-api-config
+        - name: CERT_PATH
+          value: /etc/korifi-tls
+        - name: INTERNAL_CERT_PATH
+          value: /etc/korifi-tls-internal
+        image: {{ .Values.api.image }}
+{{- if .Values.debug }}
+        command:
+        - "/dlv"
+        args:
+        - "--listen=:40000"
+        - "--headless=true"
+        - "--api-version=2"
+        - "exec"
+        - "/cfapi"
+        - "--continue"
+        - "--accept-multiclient"
+{{- end }}
+        name: korifi-api
+        ports:
+        - containerPort: {{ .Values.api.apiServer.internalPort }}
+          name: web
+        {{- include "korifi.resources" . | indent 8 }}
+        {{- include "korifi.securityContext" . | indent 8 }}
+        volumeMounts:
+        - mountPath: /etc/korifi-api-config
+          name: korifi-api-config
+          readOnly: true
+        - mountPath: /etc/korifi-tls
+          name: korifi-tls
+          readOnly: true
+        - mountPath: /etc/korifi-tls-internal
+          name: korifi-tls-internal
+          readOnly: true
+{{- if .Values.containerRegistryCACertSecret }}
+        - mountPath: /etc/ssl/certs/registry-ca.crt
+          name: korifi-registry-ca-cert
+          subPath: ca.crt
+          readOnly: true
+{{- end }}
+      {{- include "korifi.podSecurityContext" . | indent 6 }}
+      serviceAccountName: korifi-api-system-serviceaccount
+{{- if .Values.api.nodeSelector }}
+      nodeSelector:
+      {{ toYaml .Values.api.nodeSelector | indent 8 }}
+{{- end }}
+{{- if .Values.api.tolerations }}
+      tolerations:
+      {{- toYaml .Values.api.tolerations | nindent 8 }}
+{{- end }}
+      volumes:
+      - configMap:
+          name: korifi-api-config
+        name: korifi-api-config
+      - name: korifi-tls
+        secret:
+          secretName: {{ .Values.api.apiServer.ingressCertSecret }}
+      - name: korifi-tls-internal
+        secret:
+          secretName: {{ .Values.api.apiServer.internalCertSecret }}
+{{- if .Values.containerRegistryCACertSecret }}
+      - name: korifi-registry-ca-cert
+        secret:
+          secretName: {{ .Values.containerRegistryCACertSecret }}
+{{- end }}

--- a/dependencies/korifi/api/ingress-cert.yaml
+++ b/dependencies/korifi/api/ingress-cert.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.generateIngressCertificates }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ .Values.api.apiServer.ingressCertSecret }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  commonName: {{ .Values.api.apiServer.url }}
+  dnsNames:
+  - {{ .Values.api.apiServer.url }}
+  issuerRef:
+    kind: Issuer
+    name: selfsigned-issuer
+  secretName: {{ .Values.api.apiServer.ingressCertSecret }}
+{{- end }}

--- a/dependencies/korifi/api/ingress.yaml
+++ b/dependencies/korifi/api/ingress.yaml
@@ -1,0 +1,18 @@
+kind: TLSRoute
+apiVersion: gateway.networking.k8s.io/v1alpha2
+metadata:
+  name: korifi-api
+  namespace: {{ .Release.Namespace }}
+spec:
+  parentRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: korifi
+    namespace: {{ .Release.Namespace }}-gateway
+  hostnames:
+  - {{ .Values.api.apiServer.url }}
+  rules:
+  - backendRefs:
+    - kind: Service
+      name: korifi-api-svc
+      port: 443

--- a/dependencies/korifi/api/internal-cert.yaml
+++ b/dependencies/korifi/api/internal-cert.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.generateInternalCertificates }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ .Values.api.apiServer.internalCertSecret }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  isCA: true
+  commonName: korifi-api-svc.{{ .Release.Namespace }}.svc.cluster.local
+  dnsNames:
+  - korifi-api-svc.{{ .Release.Namespace }}.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: selfsigned-issuer
+  secretName: {{ .Values.api.apiServer.internalCertSecret }}
+{{- end }}

--- a/dependencies/korifi/api/rbac.yaml
+++ b/dependencies/korifi/api/rbac.yaml
@@ -1,0 +1,42 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: korifi-api-system-serviceaccount
+  namespace: {{ .Release.Namespace }}
+  {{- if .Values.eksContainerRegistryRoleARN }}
+  annotations:
+    eks.amazonaws.com/role-arn: {{ .Values.eksContainerRegistryRoleARN }}
+  {{- end }}
+imagePullSecrets:
+{{- range .Values.systemImagePullSecrets }}
+- name: {{ . | quote }}
+{{- end }}
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: korifi-api-system-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: korifi-api-system-role
+subjects:
+- kind: ServiceAccount
+  name: korifi-api-system-serviceaccount
+  namespace: {{ .Release.Namespace }}
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: korifi-api-system-rolebinding
+  namespace: {{ .Values.rootNamespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: korifi-api-system-role
+subjects:
+- kind: ServiceAccount
+  name: korifi-api-system-serviceaccount
+  namespace: {{ .Release.Namespace }}

--- a/dependencies/korifi/api/role.yaml
+++ b/dependencies/korifi/api/role.yaml
@@ -1,0 +1,58 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: korifi-api-system-role
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - list
+  - apiGroups:
+      - authentication.k8s.io
+    resources:
+      - tokenreviews
+    verbs:
+      - create
+  - apiGroups:
+      - korifi.cloudfoundry.org
+    resources:
+      - cfapps
+      - cfbuilds
+      - cfdomains
+      - cforgs
+      - cfpackages
+      - cfprocesses
+      - cfroutes
+      - cfsecuritygroups
+      - cfservicebindings
+      - cfservicebrokers
+      - cfserviceinstances
+      - cfserviceofferings
+      - cfserviceplans
+      - cfspaces
+      - cftasks
+    verbs:
+      - list
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - rolebindings
+    verbs:
+      - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: korifi-api-system-role
+  namespace: '{{ .Values.rootNamespace }}'
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+      - serviceaccounts
+    verbs:
+      - get

--- a/dependencies/korifi/api/service.yaml
+++ b/dependencies/korifi/api/service.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: korifi-api
+  name: korifi-api-svc
+  namespace: {{ .Release.Namespace }}
+spec:
+  ports:
+  - name: web
+    port: 443
+    protocol: TCP
+    targetPort: web
+  selector:
+    app: korifi-api
+  type: ClusterIP
+
+---
+{{- if .Values.debug }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: api-debug-port
+  namespace: {{ .Release.Namespace }}
+spec:
+  ports:
+    - name: debug-30052
+      nodePort: 30052
+      port: 30052
+      protocol: TCP
+      targetPort: 40000
+  selector:
+    app: korifi-api
+  type: NodePort
+{{- end }}

--- a/dependencies/korifi/controllers/cf_roles/cf_admin.yaml
+++ b/dependencies/korifi/controllers/cf_roles/cf_admin.yaml
@@ -1,0 +1,235 @@
+# The CF Admin Role
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: korifi-controllers-admin
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - patch
+  - get
+  - create
+
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - list
+  - delete
+
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
+
+- apiGroups:
+  - metrics.k8s.io
+  resources:
+  - pods
+  verbs:
+  - get
+
+- apiGroups:
+  - korifi.cloudfoundry.org
+  resources:
+  - cforgs
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - patch
+  - delete
+
+- apiGroups:
+  - korifi.cloudfoundry.org
+  resources:
+  - cfspaces
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - patch
+  - delete
+
+- apiGroups:
+  - korifi.cloudfoundry.org
+  resources:
+  - cfapps
+  verbs:
+  - get
+  - create
+  - patch
+  - delete
+  - list
+  - watch
+
+- apiGroups:
+  - korifi.cloudfoundry.org
+  resources:
+  - cfprocesses
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+
+- apiGroups:
+  - korifi.cloudfoundry.org
+  resources:
+  - cfpackages
+  verbs:
+  - get
+  - list
+  - create
+  - patch
+  - watch
+
+- apiGroups:
+  - korifi.cloudfoundry.org
+  resources:
+  - cfbuilds
+  verbs:
+  - get
+  - list
+  - create
+  - patch
+
+- apiGroups:
+  - korifi.cloudfoundry.org
+  resources:
+  - cfserviceinstances
+  verbs:
+  - get
+  - list
+  - create
+  - patch
+  - delete
+  - watch
+
+- apiGroups:
+    - korifi.cloudfoundry.org
+  resources:
+    - cfservicebindings
+  verbs:
+    - get
+    - list
+    - create
+    - delete
+    - watch
+    - patch
+
+- apiGroups:
+  - korifi.cloudfoundry.org
+  resources:
+  - cfdomains
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - delete
+
+- apiGroups:
+  - korifi.cloudfoundry.org
+  resources:
+  - cfroutes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+
+- apiGroups:
+  - korifi.cloudfoundry.org
+  resources:
+  - cftasks
+  verbs:
+  - get
+  - create
+  - delete
+  - list
+  - patch
+  - watch
+
+- apiGroups:
+  - korifi.cloudfoundry.org
+  resources:
+  - cfsecuritygroups
+  verbs:
+  - create
+
+- apiGroups:
+  - korifi.cloudfoundry.org
+  resources:
+  - appworkloads
+  verbs:
+  - list
+
+- apiGroups:
+  - korifi.cloudfoundry.org
+  resources:
+  - builderinfos
+  verbs:
+  - get
+  - list
+  - watch
+
+- apiGroups:
+  - korifi.cloudfoundry.org
+  resources:
+  - runnerinfos
+  verbs:
+  - get
+  - list
+  - watch
+
+- apiGroups:
+  - korifi.cloudfoundry.org
+  resources:
+  - cfservicebrokers
+  verbs:
+  - create
+  - get
+  - list
+  - delete
+  - patch
+
+- apiGroups:
+  - korifi.cloudfoundry.org
+  resources:
+  - cfserviceofferings
+  - cfserviceplans
+  verbs:
+  - list
+  - get
+  - patch
+  - delete
+
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  verbs:
+  - create
+  - list
+  - delete
+
+- apiGroups:
+  - metrics.k8s.io
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch

--- a/dependencies/korifi/controllers/cf_roles/cf_org_manager.yaml
+++ b/dependencies/korifi/controllers/cf_roles/cf_org_manager.yaml
@@ -1,0 +1,45 @@
+# The CF Organization Manager Role
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: korifi-controllers-organization-manager
+rules:
+- apiGroups:
+  - korifi.cloudfoundry.org
+  resources:
+  - cforgs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - korifi.cloudfoundry.org
+  resources:
+  - cfspaces
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+- apiGroups:
+  - korifi.cloudfoundry.org
+  resources:
+  - builderinfos
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - korifi.cloudfoundry.org
+  resources:
+  - runnerinfos
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  verbs:
+  - delete

--- a/dependencies/korifi/controllers/cf_roles/cf_org_user.yaml
+++ b/dependencies/korifi/controllers/cf_roles/cf_org_user.yaml
@@ -1,0 +1,29 @@
+# The CF Organization User Role
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: korifi-controllers-organization-user
+rules:
+- apiGroups:
+  - korifi.cloudfoundry.org
+  resources:
+  - cforgs
+  verbs:
+  - get
+  - list
+  - watch
+
+- apiGroups:
+  - korifi.cloudfoundry.org
+  resources:
+  - cfspaces
+  verbs:
+  - list
+  - get
+
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  verbs:
+  - list

--- a/dependencies/korifi/controllers/cf_roles/cf_root_namespace_user.yaml
+++ b/dependencies/korifi/controllers/cf_roles/cf_root_namespace_user.yaml
@@ -1,0 +1,64 @@
+# The CF Root Namespace User
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: korifi-controllers-root-namespace-user
+rules:
+- apiGroups:
+  - korifi.cloudfoundry.org
+  resources:
+  - cfdomains
+  verbs:
+  - get
+  - list
+
+- apiGroups:
+  - korifi.cloudfoundry.org
+  resources:
+  - cforgs
+  verbs:
+  - get
+  - list
+  - watch
+
+- apiGroups:
+  - korifi.cloudfoundry.org
+  resources:
+  - builderinfos
+  verbs:
+  - get
+  - list
+  - watch
+
+- apiGroups:
+  - korifi.cloudfoundry.org
+  resources:
+  - runnerinfos
+  verbs:
+  - get
+  - list
+  - watch
+
+- apiGroups:
+  - korifi.cloudfoundry.org
+  resources:
+  - cfserviceplans
+  - cfservicebrokers
+  verbs:
+  - list
+
+- apiGroups:
+  - korifi.cloudfoundry.org
+  resources:
+  - cfserviceplans
+  verbs:
+  - get
+
+- apiGroups:
+  - korifi.cloudfoundry.org
+  resources:
+  - cfserviceofferings
+  verbs:
+  - get
+  - list
+  - delete

--- a/dependencies/korifi/controllers/cf_roles/cf_space_auditor.yaml
+++ b/dependencies/korifi/controllers/cf_roles/cf_space_auditor.yaml
@@ -1,0 +1,13 @@
+# The CF Space Auditor Role
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: korifi-controllers-space-auditor
+rules:
+- apiGroups:
+  - korifi.cloudfoundry.org
+  resources:
+  - cfapps
+  verbs:
+  - get
+  - list

--- a/dependencies/korifi/controllers/cf_roles/cf_space_developer.yaml
+++ b/dependencies/korifi/controllers/cf_roles/cf_space_developer.yaml
@@ -1,0 +1,141 @@
+# The CF Space Developer Role
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: korifi-controllers-space-developer
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - patch
+  - get
+  - create
+
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - list
+  - delete
+
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
+
+- apiGroups:
+  - metrics.k8s.io
+  resources:
+  - pods
+  verbs:
+  - get
+
+- apiGroups:
+  - korifi.cloudfoundry.org
+  resources:
+  - cfapps
+  verbs:
+  - get
+  - create
+  - patch
+  - delete
+  - list
+  - watch
+
+- apiGroups:
+  - korifi.cloudfoundry.org
+  resources:
+  - appworkloads
+  verbs:
+  - list
+
+- apiGroups:
+  - korifi.cloudfoundry.org
+  resources:
+  - cfprocesses
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+
+- apiGroups:
+  - korifi.cloudfoundry.org
+  resources:
+  - cfpackages
+  verbs:
+  - get
+  - list
+  - create
+  - patch
+  - watch
+
+- apiGroups:
+  - korifi.cloudfoundry.org
+  resources:
+  - cfbuilds
+  verbs:
+  - get
+  - list
+  - create
+  - patch
+
+- apiGroups:
+  - korifi.cloudfoundry.org
+  resources:
+  - cfserviceinstances
+  verbs:
+  - get
+  - list
+  - create
+  - patch
+  - delete
+  - watch
+
+- apiGroups:
+    - korifi.cloudfoundry.org
+  resources:
+    - cfservicebindings
+  verbs:
+    - get
+    - list
+    - create
+    - delete
+    - watch
+    - patch
+
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  verbs:
+  - list
+
+- apiGroups:
+  - korifi.cloudfoundry.org
+  resources:
+  - cfroutes
+  verbs:
+  - get
+  - create
+  - delete
+  - list
+  - patch
+  - update
+
+- apiGroups:
+  - korifi.cloudfoundry.org
+  resources:
+  - cftasks
+  verbs:
+  - get
+  - create
+  - delete
+  - list
+  - patch
+  - watch

--- a/dependencies/korifi/controllers/cf_roles/cf_space_manager.yaml
+++ b/dependencies/korifi/controllers/cf_roles/cf_space_manager.yaml
@@ -1,0 +1,76 @@
+# The CF Space Manager Role
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: korifi-controllers-space-manager
+rules:
+- apiGroups:
+  - korifi.cloudfoundry.org
+  resources:
+  - cfapps
+  verbs:
+  - get
+  - list
+
+- apiGroups:
+  - korifi.cloudfoundry.org
+  resources:
+  - cfpackages
+  verbs:
+  - get
+  - list
+
+- apiGroups:
+  - korifi.cloudfoundry.org
+  resources:
+  - cfprocesses
+  verbs:
+  - get
+  - list
+
+- apiGroups:
+  - korifi.cloudfoundry.org
+  resources:
+  - cfbuilds
+  verbs:
+  - get
+  - list
+
+- apiGroups:
+  - korifi.cloudfoundry.org
+  resources:
+  - cfroutes
+  verbs:
+  - get
+  - list
+
+- apiGroups:
+  - korifi.cloudfoundry.org
+  resources:
+  - cfserviceinstances
+  verbs:
+  - list
+  - get
+
+- apiGroups:
+  - korifi.cloudfoundry.org
+  resources:
+  - cfservicebindings
+  verbs:
+  - get
+  - list
+
+- apiGroups:
+  - korifi.cloudfoundry.org
+  resources:
+  - cftasks
+  verbs:
+  - get
+  - list
+
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  verbs:
+  - delete

--- a/dependencies/korifi/controllers/configmap.yaml
+++ b/dependencies/korifi/controllers/configmap.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: korifi-controllers-config
+  namespace: {{ .Release.Namespace }}
+data:
+  config.yaml: |-
+    builderName: {{ .Values.reconcilers.build }}
+    runnerName: {{ .Values.reconcilers.run }}
+    cfProcessDefaults:
+      memoryMB: {{ .Values.controllers.processDefaults.memoryMB }}
+      diskQuotaMB: {{ .Values.controllers.processDefaults.diskQuotaMB }}
+    cfRootNamespace: {{ .Values.rootNamespace }}
+    {{- if not .Values.eksContainerRegistryRoleARN }}
+    {{- if .Values.containerRegistrySecrets }}
+    containerRegistrySecretNames:
+    {{- range .Values.containerRegistrySecrets }}
+    - {{ . | quote }}
+    {{- end }}
+    {{- else }}
+    containerRegistrySecretNames:
+    - {{ .Values.containerRegistrySecret | quote }}
+    {{- end }}
+    {{- end }}
+    taskTTL: {{ .Values.controllers.taskTTL }}
+    namespaceLabels:
+    {{- range $key, $value := .Values.controllers.namespaceLabels }}
+      {{ $key }}: {{ $value }}
+    {{- end }}
+    extraVCAPApplicationValues:
+    {{- $defaultDict := dict "cf_api" (printf "https://%s" .Values.api.apiServer.url) -}}
+    {{- range $key, $value := merge .Values.controllers.extraVCAPApplicationValues $defaultDict }}
+      {{ $key }}: {{ $value }}
+    {{- end }}
+    maxRetainedPackagesPerApp: {{ .Values.controllers.maxRetainedPackagesPerApp }}
+    maxRetainedBuildsPerApp: {{ .Values.controllers.maxRetainedBuildsPerApp }}
+    logLevel: {{ .Values.logLevel }}
+    networking:
+      gatewayNamespace: {{ .Release.Namespace }}-gateway
+      gatewayName: korifi
+    experimentalManagedServicesEnabled: {{ .Values.experimental.managedServices.enabled }}
+    trustInsecureServiceBrokers: {{ .Values.experimental.managedServices.trustInsecureBrokers }}
+    disableRouteController: {{ .Values.experimental.routing.disableRouteController }}

--- a/dependencies/korifi/controllers/crds/korifi.cloudfoundry.org_appworkloads.yaml
+++ b/dependencies/korifi/controllers/crds/korifi.cloudfoundry.org_appworkloads.yaml
@@ -1,0 +1,888 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  name: appworkloads.korifi.cloudfoundry.org
+spec:
+  group: korifi.cloudfoundry.org
+  names:
+    kind: AppWorkload
+    listKind: AppWorkloadList
+    plural: appworkloads
+    singular: appworkload
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: AppWorkload is the Schema for the appworkloads API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AppWorkloadSpec defines the desired state of AppWorkload
+            properties:
+              GUID:
+                type: string
+              appGUID:
+                type: string
+              command:
+                items:
+                  type: string
+                type: array
+              env:
+                items:
+                  description: EnvVar represents an environment variable present in
+                    a Container.
+                  properties:
+                    name:
+                      description: |-
+                        Name of the environment variable.
+                        May consist of any printable ASCII characters except '='.
+                      type: string
+                    value:
+                      description: |-
+                        Variable references $(VAR_NAME) are expanded
+                        using the previously defined environment variables in the container and
+                        any service environment variables. If a variable cannot be resolved,
+                        the reference in the input string will be unchanged. Double $$ are reduced
+                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                        "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                        Escaped references will never be expanded, regardless of whether the variable
+                        exists or not.
+                        Defaults to "".
+                      type: string
+                    valueFrom:
+                      description: Source for the environment variable's value. Cannot
+                        be used if value is not empty.
+                      properties:
+                        configMapKeyRef:
+                          description: Selects a key of a ConfigMap.
+                          properties:
+                            key:
+                              description: The key to select.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap or its key
+                                must be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        fieldRef:
+                          description: |-
+                            Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                            spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                          properties:
+                            apiVersion:
+                              description: Version of the schema the FieldPath is
+                                written in terms of, defaults to "v1".
+                              type: string
+                            fieldPath:
+                              description: Path of the field to select in the specified
+                                API version.
+                              type: string
+                          required:
+                          - fieldPath
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        fileKeyRef:
+                          description: |-
+                            FileKeyRef selects a key of the env file.
+                            Requires the EnvFiles feature gate to be enabled.
+                          properties:
+                            key:
+                              description: |-
+                                The key within the env file. An invalid key will prevent the pod from starting.
+                                The keys defined within a source may consist of any printable ASCII characters except '='.
+                                During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                              type: string
+                            optional:
+                              default: false
+                              description: |-
+                                Specify whether the file or its key must be defined. If the file or key
+                                does not exist, then the env var is not published.
+                                If optional is set to true and the specified key does not exist,
+                                the environment variable will not be set in the Pod's containers.
+
+                                If optional is set to false and the specified key does not exist,
+                                an error will be returned during Pod creation.
+                              type: boolean
+                            path:
+                              description: |-
+                                The path within the volume from which to select the file.
+                                Must be relative and may not contain the '..' path or start with '..'.
+                              type: string
+                            volumeName:
+                              description: The name of the volume mount containing
+                                the env file.
+                              type: string
+                          required:
+                          - key
+                          - path
+                          - volumeName
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        resourceFieldRef:
+                          description: |-
+                            Selects a resource of the container: only resources limits and requests
+                            (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                          properties:
+                            containerName:
+                              description: 'Container name: required for volumes,
+                                optional for env vars'
+                              type: string
+                            divisor:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Specifies the output format of the exposed
+                                resources, defaults to "1"
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            resource:
+                              description: 'Required: resource to select'
+                              type: string
+                          required:
+                          - resource
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        secretKeyRef:
+                          description: Selects a key of a secret in the pod's namespace
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
+              image:
+                type: string
+              imagePullSecrets:
+                description: |-
+                  An optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec.
+                  If specified, these secrets will be passed to individual puller implementations for them to use.
+                  More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
+                items:
+                  description: |-
+                    LocalObjectReference contains enough information to let you locate the
+                    referenced object inside the same namespace.
+                  properties:
+                    name:
+                      default: ""
+                      description: |-
+                        Name of the referent.
+                        This field is effectively required, but due to backwards compatibility is
+                        allowed to be empty. Instances of this type with an empty value here are
+                        almost certainly wrong.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      type: string
+                  type: object
+                  x-kubernetes-map-type: atomic
+                type: array
+              instances:
+                default: 1
+                format: int32
+                type: integer
+              livenessProbe:
+                description: |-
+                  Probe describes a health check to be performed against a container to determine whether it is
+                  alive or ready to receive traffic.
+                properties:
+                  exec:
+                    description: Exec specifies a command to execute in the container.
+                    properties:
+                      command:
+                        description: |-
+                          Command is the command line to execute inside the container, the working directory for the
+                          command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                          not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                          a shell, you need to explicitly call out to that shell.
+                          Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                    type: object
+                  failureThreshold:
+                    description: |-
+                      Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                      Defaults to 3. Minimum value is 1.
+                    format: int32
+                    type: integer
+                  grpc:
+                    description: GRPC specifies a GRPC HealthCheckRequest.
+                    properties:
+                      port:
+                        description: Port number of the gRPC service. Number must
+                          be in the range 1 to 65535.
+                        format: int32
+                        type: integer
+                      service:
+                        default: ""
+                        description: |-
+                          Service is the name of the service to place in the gRPC HealthCheckRequest
+                          (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                          If this is not specified, the default behavior is defined by gRPC.
+                        type: string
+                    required:
+                    - port
+                    type: object
+                  httpGet:
+                    description: HTTPGet specifies an HTTP GET request to perform.
+                    properties:
+                      host:
+                        description: |-
+                          Host name to connect to, defaults to the pod IP. You probably want to set
+                          "Host" in httpHeaders instead.
+                        type: string
+                      httpHeaders:
+                        description: Custom headers to set in the request. HTTP allows
+                          repeated headers.
+                        items:
+                          description: HTTPHeader describes a custom header to be
+                            used in HTTP probes
+                          properties:
+                            name:
+                              description: |-
+                                The header field name.
+                                This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                              type: string
+                            value:
+                              description: The header field value
+                              type: string
+                          required:
+                          - name
+                          - value
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      path:
+                        description: Path to access on the HTTP server.
+                        type: string
+                      port:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: |-
+                          Name or number of the port to access on the container.
+                          Number must be in the range 1 to 65535.
+                          Name must be an IANA_SVC_NAME.
+                        x-kubernetes-int-or-string: true
+                      scheme:
+                        description: |-
+                          Scheme to use for connecting to the host.
+                          Defaults to HTTP.
+                        type: string
+                    required:
+                    - port
+                    type: object
+                  initialDelaySeconds:
+                    description: |-
+                      Number of seconds after the container has started before liveness probes are initiated.
+                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                    format: int32
+                    type: integer
+                  periodSeconds:
+                    description: |-
+                      How often (in seconds) to perform the probe.
+                      Default to 10 seconds. Minimum value is 1.
+                    format: int32
+                    type: integer
+                  successThreshold:
+                    description: |-
+                      Minimum consecutive successes for the probe to be considered successful after having failed.
+                      Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                    format: int32
+                    type: integer
+                  tcpSocket:
+                    description: TCPSocket specifies a connection to a TCP port.
+                    properties:
+                      host:
+                        description: 'Optional: Host name to connect to, defaults
+                          to the pod IP.'
+                        type: string
+                      port:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: |-
+                          Number or name of the port to access on the container.
+                          Number must be in the range 1 to 65535.
+                          Name must be an IANA_SVC_NAME.
+                        x-kubernetes-int-or-string: true
+                    required:
+                    - port
+                    type: object
+                  terminationGracePeriodSeconds:
+                    description: |-
+                      Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                      The grace period is the duration in seconds after the processes running in the pod are sent
+                      a termination signal and the time when the processes are forcibly halted with a kill signal.
+                      Set this value longer than the expected cleanup time for your process.
+                      If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                      value overrides the value provided by the pod spec.
+                      Value must be non-negative integer. The value zero indicates stop immediately via
+                      the kill signal (no opportunity to shut down).
+                      This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                      Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                    format: int64
+                    type: integer
+                  timeoutSeconds:
+                    description: |-
+                      Number of seconds after which the probe times out.
+                      Defaults to 1 second. Minimum value is 1.
+                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                    format: int32
+                    type: integer
+                type: object
+              ports:
+                items:
+                  format: int32
+                  type: integer
+                type: array
+              processType:
+                type: string
+              readinessProbe:
+                description: |-
+                  Probe describes a health check to be performed against a container to determine whether it is
+                  alive or ready to receive traffic.
+                properties:
+                  exec:
+                    description: Exec specifies a command to execute in the container.
+                    properties:
+                      command:
+                        description: |-
+                          Command is the command line to execute inside the container, the working directory for the
+                          command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                          not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                          a shell, you need to explicitly call out to that shell.
+                          Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                    type: object
+                  failureThreshold:
+                    description: |-
+                      Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                      Defaults to 3. Minimum value is 1.
+                    format: int32
+                    type: integer
+                  grpc:
+                    description: GRPC specifies a GRPC HealthCheckRequest.
+                    properties:
+                      port:
+                        description: Port number of the gRPC service. Number must
+                          be in the range 1 to 65535.
+                        format: int32
+                        type: integer
+                      service:
+                        default: ""
+                        description: |-
+                          Service is the name of the service to place in the gRPC HealthCheckRequest
+                          (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                          If this is not specified, the default behavior is defined by gRPC.
+                        type: string
+                    required:
+                    - port
+                    type: object
+                  httpGet:
+                    description: HTTPGet specifies an HTTP GET request to perform.
+                    properties:
+                      host:
+                        description: |-
+                          Host name to connect to, defaults to the pod IP. You probably want to set
+                          "Host" in httpHeaders instead.
+                        type: string
+                      httpHeaders:
+                        description: Custom headers to set in the request. HTTP allows
+                          repeated headers.
+                        items:
+                          description: HTTPHeader describes a custom header to be
+                            used in HTTP probes
+                          properties:
+                            name:
+                              description: |-
+                                The header field name.
+                                This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                              type: string
+                            value:
+                              description: The header field value
+                              type: string
+                          required:
+                          - name
+                          - value
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      path:
+                        description: Path to access on the HTTP server.
+                        type: string
+                      port:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: |-
+                          Name or number of the port to access on the container.
+                          Number must be in the range 1 to 65535.
+                          Name must be an IANA_SVC_NAME.
+                        x-kubernetes-int-or-string: true
+                      scheme:
+                        description: |-
+                          Scheme to use for connecting to the host.
+                          Defaults to HTTP.
+                        type: string
+                    required:
+                    - port
+                    type: object
+                  initialDelaySeconds:
+                    description: |-
+                      Number of seconds after the container has started before liveness probes are initiated.
+                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                    format: int32
+                    type: integer
+                  periodSeconds:
+                    description: |-
+                      How often (in seconds) to perform the probe.
+                      Default to 10 seconds. Minimum value is 1.
+                    format: int32
+                    type: integer
+                  successThreshold:
+                    description: |-
+                      Minimum consecutive successes for the probe to be considered successful after having failed.
+                      Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                    format: int32
+                    type: integer
+                  tcpSocket:
+                    description: TCPSocket specifies a connection to a TCP port.
+                    properties:
+                      host:
+                        description: 'Optional: Host name to connect to, defaults
+                          to the pod IP.'
+                        type: string
+                      port:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: |-
+                          Number or name of the port to access on the container.
+                          Number must be in the range 1 to 65535.
+                          Name must be an IANA_SVC_NAME.
+                        x-kubernetes-int-or-string: true
+                    required:
+                    - port
+                    type: object
+                  terminationGracePeriodSeconds:
+                    description: |-
+                      Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                      The grace period is the duration in seconds after the processes running in the pod are sent
+                      a termination signal and the time when the processes are forcibly halted with a kill signal.
+                      Set this value longer than the expected cleanup time for your process.
+                      If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                      value overrides the value provided by the pod spec.
+                      Value must be non-negative integer. The value zero indicates stop immediately via
+                      the kill signal (no opportunity to shut down).
+                      This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                      Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                    format: int64
+                    type: integer
+                  timeoutSeconds:
+                    description: |-
+                      Number of seconds after which the probe times out.
+                      Defaults to 1 second. Minimum value is 1.
+                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                    format: int32
+                    type: integer
+                type: object
+              resources:
+                description: ResourceRequirements describes the compute resource requirements.
+                properties:
+                  claims:
+                    description: |-
+                      Claims lists the names of resources, defined in spec.resourceClaims,
+                      that are used by this container.
+
+                      This field depends on the
+                      DynamicResourceAllocation feature gate.
+
+                      This field is immutable. It can only be set for containers.
+                    items:
+                      description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                      properties:
+                        name:
+                          description: |-
+                            Name must match the name of one entry in pod.spec.resourceClaims of
+                            the Pod where this field is used. It makes that resource available
+                            inside a container.
+                          type: string
+                        request:
+                          description: |-
+                            Request is the name chosen for a request in the referenced claim.
+                            If empty, everything from the claim is made available, otherwise
+                            only the result of this request.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                  limits:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: |-
+                      Limits describes the maximum amount of compute resources allowed.
+                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    type: object
+                  requests:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: |-
+                      Requests describes the minimum amount of compute resources required.
+                      If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                      otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    type: object
+                type: object
+              runnerName:
+                description: The name of the runner that should reconcile this AppWorkload
+                  resource and execute running its instances
+                type: string
+              services:
+                description: |-
+                  Reference to service credentials secrets to be projected onto the app workload
+                  They are in the [servicebinding.io](https://servicebinding.io/spec/core/1.1.0/) format
+                items:
+                  properties:
+                    guid:
+                      description: the guid of the CFserviceBinding
+                      type: string
+                    name:
+                      description: The name of binding. Used as binding name when
+                        projecting the secret onto the workload
+                      type: string
+                    secret:
+                      description: Name of the binding secret
+                      type: string
+                  required:
+                  - guid
+                  - name
+                  - secret
+                  type: object
+                type: array
+              startupProbe:
+                description: |-
+                  Probe describes a health check to be performed against a container to determine whether it is
+                  alive or ready to receive traffic.
+                properties:
+                  exec:
+                    description: Exec specifies a command to execute in the container.
+                    properties:
+                      command:
+                        description: |-
+                          Command is the command line to execute inside the container, the working directory for the
+                          command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                          not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                          a shell, you need to explicitly call out to that shell.
+                          Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                    type: object
+                  failureThreshold:
+                    description: |-
+                      Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                      Defaults to 3. Minimum value is 1.
+                    format: int32
+                    type: integer
+                  grpc:
+                    description: GRPC specifies a GRPC HealthCheckRequest.
+                    properties:
+                      port:
+                        description: Port number of the gRPC service. Number must
+                          be in the range 1 to 65535.
+                        format: int32
+                        type: integer
+                      service:
+                        default: ""
+                        description: |-
+                          Service is the name of the service to place in the gRPC HealthCheckRequest
+                          (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                          If this is not specified, the default behavior is defined by gRPC.
+                        type: string
+                    required:
+                    - port
+                    type: object
+                  httpGet:
+                    description: HTTPGet specifies an HTTP GET request to perform.
+                    properties:
+                      host:
+                        description: |-
+                          Host name to connect to, defaults to the pod IP. You probably want to set
+                          "Host" in httpHeaders instead.
+                        type: string
+                      httpHeaders:
+                        description: Custom headers to set in the request. HTTP allows
+                          repeated headers.
+                        items:
+                          description: HTTPHeader describes a custom header to be
+                            used in HTTP probes
+                          properties:
+                            name:
+                              description: |-
+                                The header field name.
+                                This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                              type: string
+                            value:
+                              description: The header field value
+                              type: string
+                          required:
+                          - name
+                          - value
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      path:
+                        description: Path to access on the HTTP server.
+                        type: string
+                      port:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: |-
+                          Name or number of the port to access on the container.
+                          Number must be in the range 1 to 65535.
+                          Name must be an IANA_SVC_NAME.
+                        x-kubernetes-int-or-string: true
+                      scheme:
+                        description: |-
+                          Scheme to use for connecting to the host.
+                          Defaults to HTTP.
+                        type: string
+                    required:
+                    - port
+                    type: object
+                  initialDelaySeconds:
+                    description: |-
+                      Number of seconds after the container has started before liveness probes are initiated.
+                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                    format: int32
+                    type: integer
+                  periodSeconds:
+                    description: |-
+                      How often (in seconds) to perform the probe.
+                      Default to 10 seconds. Minimum value is 1.
+                    format: int32
+                    type: integer
+                  successThreshold:
+                    description: |-
+                      Minimum consecutive successes for the probe to be considered successful after having failed.
+                      Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                    format: int32
+                    type: integer
+                  tcpSocket:
+                    description: TCPSocket specifies a connection to a TCP port.
+                    properties:
+                      host:
+                        description: 'Optional: Host name to connect to, defaults
+                          to the pod IP.'
+                        type: string
+                      port:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: |-
+                          Number or name of the port to access on the container.
+                          Number must be in the range 1 to 65535.
+                          Name must be an IANA_SVC_NAME.
+                        x-kubernetes-int-or-string: true
+                    required:
+                    - port
+                    type: object
+                  terminationGracePeriodSeconds:
+                    description: |-
+                      Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                      The grace period is the duration in seconds after the processes running in the pod are sent
+                      a termination signal and the time when the processes are forcibly halted with a kill signal.
+                      Set this value longer than the expected cleanup time for your process.
+                      If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                      value overrides the value provided by the pod spec.
+                      Value must be non-negative integer. The value zero indicates stop immediately via
+                      the kill signal (no opportunity to shut down).
+                      This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                      Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                    format: int64
+                    type: integer
+                  timeoutSeconds:
+                    description: |-
+                      Number of seconds after which the probe times out.
+                      Defaults to 1 second. Minimum value is 1.
+                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                    format: int32
+                    type: integer
+                type: object
+              version:
+                type: string
+            required:
+            - GUID
+            - appGUID
+            - image
+            - instances
+            - processType
+            - runnerName
+            - version
+            type: object
+          status:
+            description: AppWorkloadStatus defines the observed state of AppWorkload
+            properties:
+              actualInstances:
+                format: int32
+                type: integer
+              conditions:
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              instancesStatus:
+                additionalProperties:
+                  properties:
+                    state:
+                      description: The state of the instance
+                      enum:
+                      - DOWN
+                      - CRASHED
+                      - STARTING
+                      - RUNNING
+                      type: string
+                    timestamp:
+                      description: The time the instance got into this status; nil
+                        if unknown
+                      format: date-time
+                      type: string
+                  required:
+                  - state
+                  type: object
+                type: object
+              observedGeneration:
+                description: ObservedGeneration captures the latest generation of
+                  the AppWorkload that has been reconciled
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/dependencies/korifi/controllers/crds/korifi.cloudfoundry.org_builderinfos.yaml
+++ b/dependencies/korifi/controllers/crds/korifi.cloudfoundry.org_builderinfos.yaml
@@ -1,0 +1,164 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  name: builderinfos.korifi.cloudfoundry.org
+spec:
+  group: korifi.cloudfoundry.org
+  names:
+    kind: BuilderInfo
+    listKind: BuilderInfoList
+    plural: builderinfos
+    singular: builderinfo
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.conditions[?(@.type=='Ready')].status
+      name: Ready
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: BuilderInfo is the Schema for the builderinfos API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: BuilderInfoSpec defines the desired state of BuilderInfo
+            type: object
+          status:
+            description: BuilderInfoStatus defines the observed state of BuilderInfo
+            properties:
+              buildpacks:
+                items:
+                  properties:
+                    creationTimestamp:
+                      format: date-time
+                      type: string
+                    name:
+                      type: string
+                    stack:
+                      type: string
+                    updatedTimestamp:
+                      format: date-time
+                      type: string
+                    version:
+                      type: string
+                  required:
+                  - creationTimestamp
+                  - name
+                  - stack
+                  - updatedTimestamp
+                  - version
+                  type: object
+                type: array
+              conditions:
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: ObservedGeneration captures the latest generation of
+                  the BuilderInfo that has been reconciled
+                format: int64
+                type: integer
+              stacks:
+                items:
+                  properties:
+                    creationTimestamp:
+                      format: date-time
+                      type: string
+                    description:
+                      type: string
+                    name:
+                      type: string
+                    updatedTimestamp:
+                      format: date-time
+                      type: string
+                  required:
+                  - creationTimestamp
+                  - description
+                  - name
+                  - updatedTimestamp
+                  type: object
+                type: array
+            required:
+            - buildpacks
+            - stacks
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/dependencies/korifi/controllers/crds/korifi.cloudfoundry.org_buildworkloads.yaml
+++ b/dependencies/korifi/controllers/crds/korifi.cloudfoundry.org_buildworkloads.yaml
@@ -1,0 +1,437 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  name: buildworkloads.korifi.cloudfoundry.org
+spec:
+  group: korifi.cloudfoundry.org
+  names:
+    kind: BuildWorkload
+    listKind: BuildWorkloadList
+    plural: buildworkloads
+    singular: buildworkload
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: BuildWorkload is the Schema for the buildworkloads API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: BuildWorkloadSpec defines the desired state of BuildWorkload
+            properties:
+              buildRef:
+                description: A reference to the CFBuild that requested the build.
+                  The CFBuild must be in the same namespace
+                properties:
+                  name:
+                    type: string
+                required:
+                - name
+                type: object
+              builderName:
+                description: The name of the builder that should reconcile this BuildWorkload
+                  resource and execute the image building
+                type: string
+              buildpacks:
+                description: |-
+                  Buildpacks to include in auto-detection when building the app image.
+                  If no values are specified, then all available buildpacks will be used for auto-detection
+                items:
+                  type: string
+                type: array
+              env:
+                description: The environment variables to set on the container that
+                  builds the image
+                items:
+                  description: EnvVar represents an environment variable present in
+                    a Container.
+                  properties:
+                    name:
+                      description: |-
+                        Name of the environment variable.
+                        May consist of any printable ASCII characters except '='.
+                      type: string
+                    value:
+                      description: |-
+                        Variable references $(VAR_NAME) are expanded
+                        using the previously defined environment variables in the container and
+                        any service environment variables. If a variable cannot be resolved,
+                        the reference in the input string will be unchanged. Double $$ are reduced
+                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                        "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                        Escaped references will never be expanded, regardless of whether the variable
+                        exists or not.
+                        Defaults to "".
+                      type: string
+                    valueFrom:
+                      description: Source for the environment variable's value. Cannot
+                        be used if value is not empty.
+                      properties:
+                        configMapKeyRef:
+                          description: Selects a key of a ConfigMap.
+                          properties:
+                            key:
+                              description: The key to select.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap or its key
+                                must be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        fieldRef:
+                          description: |-
+                            Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                            spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                          properties:
+                            apiVersion:
+                              description: Version of the schema the FieldPath is
+                                written in terms of, defaults to "v1".
+                              type: string
+                            fieldPath:
+                              description: Path of the field to select in the specified
+                                API version.
+                              type: string
+                          required:
+                          - fieldPath
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        fileKeyRef:
+                          description: |-
+                            FileKeyRef selects a key of the env file.
+                            Requires the EnvFiles feature gate to be enabled.
+                          properties:
+                            key:
+                              description: |-
+                                The key within the env file. An invalid key will prevent the pod from starting.
+                                The keys defined within a source may consist of any printable ASCII characters except '='.
+                                During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                              type: string
+                            optional:
+                              default: false
+                              description: |-
+                                Specify whether the file or its key must be defined. If the file or key
+                                does not exist, then the env var is not published.
+                                If optional is set to true and the specified key does not exist,
+                                the environment variable will not be set in the Pod's containers.
+
+                                If optional is set to false and the specified key does not exist,
+                                an error will be returned during Pod creation.
+                              type: boolean
+                            path:
+                              description: |-
+                                The path within the volume from which to select the file.
+                                Must be relative and may not contain the '..' path or start with '..'.
+                              type: string
+                            volumeName:
+                              description: The name of the volume mount containing
+                                the env file.
+                              type: string
+                          required:
+                          - key
+                          - path
+                          - volumeName
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        resourceFieldRef:
+                          description: |-
+                            Selects a resource of the container: only resources limits and requests
+                            (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                          properties:
+                            containerName:
+                              description: 'Container name: required for volumes,
+                                optional for env vars'
+                              type: string
+                            divisor:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Specifies the output format of the exposed
+                                resources, defaults to "1"
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            resource:
+                              description: 'Required: resource to select'
+                              type: string
+                          required:
+                          - resource
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        secretKeyRef:
+                          description: Selects a key of a secret in the pod's namespace
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
+              services:
+                items:
+                  description: ObjectReference contains enough information to let
+                    you inspect or modify the referred object.
+                  properties:
+                    apiVersion:
+                      description: API version of the referent.
+                      type: string
+                    fieldPath:
+                      description: |-
+                        If referring to a piece of an object instead of an entire object, this string
+                        should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                        For example, if the object reference is to a container within a pod, this would take on a value like:
+                        "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                        the event) or if no container name is specified "spec.containers[2]" (container with
+                        index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                        referencing a part of an object.
+                      type: string
+                    kind:
+                      description: |-
+                        Kind of the referent.
+                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                      type: string
+                    name:
+                      description: |-
+                        Name of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      type: string
+                    namespace:
+                      description: |-
+                        Namespace of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                      type: string
+                    resourceVersion:
+                      description: |-
+                        Specific resourceVersion to which this reference is made, if any.
+                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                      type: string
+                    uid:
+                      description: |-
+                        UID of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                      type: string
+                  type: object
+                  x-kubernetes-map-type: atomic
+                type: array
+              source:
+                description: The details necessary to pull the image containing the
+                  application source
+                properties:
+                  registry:
+                    description: registry (i.e an OCI image in a registry that contains
+                      application source)
+                    properties:
+                      image:
+                        description: The location of the source image
+                        type: string
+                      imagePullSecrets:
+                        description: A list of secrets required to pull the image
+                          from its repository
+                        items:
+                          description: |-
+                            LocalObjectReference contains enough information to let you locate the
+                            referenced object inside the same namespace.
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        type: array
+                    required:
+                    - image
+                    type: object
+                required:
+                - registry
+                type: object
+            required:
+            - buildRef
+            - builderName
+            type: object
+          status:
+            description: BuildWorkloadStatus defines the observed state of BuildWorkload
+            properties:
+              conditions:
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              droplet:
+                description: BuildDropletStatus defines the observed state of the
+                  CFBuild's Droplet or runnable image
+                properties:
+                  ports:
+                    description: The exposed ports for the application
+                    items:
+                      format: int32
+                      type: integer
+                    type: array
+                  processTypes:
+                    description: The process types and associated start commands for
+                      the Droplet
+                    items:
+                      description: ProcessType is a map of process names and associated
+                        start commands for the Droplet
+                      properties:
+                        command:
+                          type: string
+                        type:
+                          type: string
+                      required:
+                      - command
+                      - type
+                      type: object
+                    type: array
+                  registry:
+                    description: The Container registry image, and secrets to access
+                    properties:
+                      image:
+                        description: The location of the source image
+                        type: string
+                      imagePullSecrets:
+                        description: A list of secrets required to pull the image
+                          from its repository
+                        items:
+                          description: |-
+                            LocalObjectReference contains enough information to let you locate the
+                            referenced object inside the same namespace.
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        type: array
+                    required:
+                    - image
+                    type: object
+                  stack:
+                    description: The stack used to build the Droplet
+                    type: string
+                required:
+                - registry
+                type: object
+              observedGeneration:
+                description: ObservedGeneration captures the latest generation of
+                  the BuildWorkload that has been reconciled
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/dependencies/korifi/controllers/crds/korifi.cloudfoundry.org_cfapps.yaml
+++ b/dependencies/korifi/controllers/crds/korifi.cloudfoundry.org_cfapps.yaml
@@ -1,0 +1,233 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  name: cfapps.korifi.cloudfoundry.org
+spec:
+  group: korifi.cloudfoundry.org
+  names:
+    kind: CFApp
+    listKind: CFAppList
+    plural: cfapps
+    singular: cfapp
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.displayName
+      name: Display Name
+      type: string
+    - jsonPath: .metadata.labels.korifi\.cloudfoundry\.org/created_at
+      name: Created At
+      type: string
+    - jsonPath: .metadata.labels.korifi\.cloudfoundry\.org/updated_at
+      name: Updated At
+      type: string
+    - jsonPath: .spec.desiredState
+      name: State
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: CFApp is the Schema for the cfapps API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CFAppSpec defines the desired state of CFApp
+            properties:
+              currentDropletRef:
+                description: A reference to the CFBuild currently assigned to the
+                  app. The CFBuild must be in the same namespace.
+                properties:
+                  name:
+                    default: ""
+                    description: |-
+                      Name of the referent.
+                      This field is effectively required, but due to backwards compatibility is
+                      allowed to be empty. Instances of this type with an empty value here are
+                      almost certainly wrong.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              desiredState:
+                description: |-
+                  The user-requested state of the CFApp. The currently-applied state of the CFApp is in status.ObservedDesiredState.
+                  Allowed values are "STARTED", and "STOPPED".
+                enum:
+                - STOPPED
+                - STARTED
+                type: string
+              displayName:
+                description: |-
+                  The mutable, user-friendly name of the app. Unlike metadata.name, the user can change this field.
+                  This is more restrictive than CC's app model- to make default route validation errors less likely
+                pattern: ^[-\w]+$
+                type: string
+              envSecretName:
+                description: The name of a Secret in the same namespace, which contains
+                  the environment variables to be set on every one of its running
+                  containers (via AppWorkload)
+                type: string
+              lifecycle:
+                description: Specifies how to build images for the app
+                properties:
+                  data:
+                    description: Data used to specify details for the Lifecycle
+                    properties:
+                      buildpacks:
+                        description: |-
+                          Buildpacks to include in auto-detection when building the app image.
+                          If no values are specified, then all available buildpacks will be used for auto-detection
+                        items:
+                          type: string
+                        type: array
+                      stack:
+                        description: Stack to use when building the app image
+                        type: string
+                    required:
+                    - stack
+                    type: object
+                  type:
+                    description: |-
+                      The CF Lifecycle type.
+                      Only "buildpack" and "docker" are currently allowed
+                    enum:
+                    - buildpack
+                    - docker
+                    type: string
+                required:
+                - data
+                - type
+                type: object
+            required:
+            - desiredState
+            - displayName
+            - lifecycle
+            type: object
+          status:
+            description: CFAppStatus defines the observed state of CFApp
+            properties:
+              actualState:
+                description: AppState defines the desired state of CFApp.
+                type: string
+              conditions:
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedDesiredState:
+                description: 'Deprecated: No longer used'
+                type: string
+              observedGeneration:
+                description: ObservedGeneration captures the latest generation of
+                  the CFApp that has been reconciled
+                format: int64
+                type: integer
+              serviceBindings:
+                description: |-
+                  Reference to service credentials secrets to be projected onto the app workload
+                  They are in the [servicebinding.io](https://servicebinding.io/spec/core/1.1.0/) format
+                items:
+                  properties:
+                    guid:
+                      description: the guid of the CFserviceBinding
+                      type: string
+                    name:
+                      description: The name of binding. Used as binding name when
+                        projecting the secret onto the workload
+                      type: string
+                    secret:
+                      description: Name of the binding secret
+                      type: string
+                  required:
+                  - guid
+                  - name
+                  - secret
+                  type: object
+                type: array
+              vcapApplicationSecretName:
+                description: VCAPApplicationSecretName contains the name of the CFApp's
+                  VCAP_APPLICATION Secret, which should exist in the same namespace
+                type: string
+              vcapServicesSecretName:
+                description: VCAPServicesSecretName contains the name of the CFApp's
+                  VCAP_SERVICES Secret, which should exist in the same namespace
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/dependencies/korifi/controllers/crds/korifi.cloudfoundry.org_cfbuilds.yaml
+++ b/dependencies/korifi/controllers/crds/korifi.cloudfoundry.org_cfbuilds.yaml
@@ -1,0 +1,269 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  name: cfbuilds.korifi.cloudfoundry.org
+spec:
+  group: korifi.cloudfoundry.org
+  names:
+    kind: CFBuild
+    listKind: CFBuildList
+    plural: cfbuilds
+    singular: cfbuild
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.appRef.name
+      name: AppGUID
+      type: string
+    - jsonPath: .status.state
+      name: State
+      type: string
+    - jsonPath: .metadata.labels.korifi\.cloudfoundry\.org/created_at
+      name: Created At
+      type: string
+    - jsonPath: .metadata.labels.korifi\.cloudfoundry\.org/updated_at
+      name: Updated At
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: CFBuild is the Schema for the cfbuilds API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CFBuildSpec defines the desired state of CFBuild
+            properties:
+              appRef:
+                description: The CFApp associated with this build. Must be in the
+                  same namespace
+                properties:
+                  name:
+                    default: ""
+                    description: |-
+                      Name of the referent.
+                      This field is effectively required, but due to backwards compatibility is
+                      allowed to be empty. Instances of this type with an empty value here are
+                      almost certainly wrong.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              lifecycle:
+                description: Specifies the buildpacks and stack for the build
+                properties:
+                  data:
+                    description: Data used to specify details for the Lifecycle
+                    properties:
+                      buildpacks:
+                        description: |-
+                          Buildpacks to include in auto-detection when building the app image.
+                          If no values are specified, then all available buildpacks will be used for auto-detection
+                        items:
+                          type: string
+                        type: array
+                      stack:
+                        description: Stack to use when building the app image
+                        type: string
+                    required:
+                    - stack
+                    type: object
+                  type:
+                    description: |-
+                      The CF Lifecycle type.
+                      Only "buildpack" and "docker" are currently allowed
+                    enum:
+                    - buildpack
+                    - docker
+                    type: string
+                required:
+                - data
+                - type
+                type: object
+              packageRef:
+                description: The CFPackage associated with this build. Must be in
+                  the same namespace
+                properties:
+                  name:
+                    default: ""
+                    description: |-
+                      Name of the referent.
+                      This field is effectively required, but due to backwards compatibility is
+                      allowed to be empty. Instances of this type with an empty value here are
+                      almost certainly wrong.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              stagingDiskMB:
+                description: 'Unimplemented: StagingDiskMB is the ephemeral-disk size
+                  request for the pod that will stage the image'
+                type: integer
+              stagingMemoryMB:
+                description: The memory limit for the pod that will stage the image
+                type: integer
+            required:
+            - appRef
+            - lifecycle
+            - packageRef
+            - stagingDiskMB
+            - stagingMemoryMB
+            type: object
+          status:
+            description: CFBuildStatus defines the observed state of CFBuild
+            properties:
+              conditions:
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              droplet:
+                description: BuildDropletStatus defines the observed state of the
+                  CFBuild's Droplet or runnable image
+                properties:
+                  ports:
+                    description: The exposed ports for the application
+                    items:
+                      format: int32
+                      type: integer
+                    type: array
+                  processTypes:
+                    description: The process types and associated start commands for
+                      the Droplet
+                    items:
+                      description: ProcessType is a map of process names and associated
+                        start commands for the Droplet
+                      properties:
+                        command:
+                          type: string
+                        type:
+                          type: string
+                      required:
+                      - command
+                      - type
+                      type: object
+                    type: array
+                  registry:
+                    description: The Container registry image, and secrets to access
+                    properties:
+                      image:
+                        description: The location of the source image
+                        type: string
+                      imagePullSecrets:
+                        description: A list of secrets required to pull the image
+                          from its repository
+                        items:
+                          description: |-
+                            LocalObjectReference contains enough information to let you locate the
+                            referenced object inside the same namespace.
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        type: array
+                    required:
+                    - image
+                    type: object
+                  stack:
+                    description: The stack used to build the Droplet
+                    type: string
+                required:
+                - registry
+                type: object
+              observedGeneration:
+                description: ObservedGeneration captures the latest generation of
+                  the CFBuild that has been reconciled
+                format: int64
+                type: integer
+              state:
+                enum:
+                - STAGING
+                - STAGED
+                - FAILED
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/dependencies/korifi/controllers/crds/korifi.cloudfoundry.org_cfdomains.yaml
+++ b/dependencies/korifi/controllers/crds/korifi.cloudfoundry.org_cfdomains.yaml
@@ -1,0 +1,131 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  name: cfdomains.korifi.cloudfoundry.org
+spec:
+  group: korifi.cloudfoundry.org
+  names:
+    kind: CFDomain
+    listKind: CFDomainList
+    plural: cfdomains
+    singular: cfdomain
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.name
+      name: Domain Name
+      type: string
+    - jsonPath: .metadata.labels.korifi\.cloudfoundry\.org/created_at
+      name: Created At
+      type: string
+    - jsonPath: .metadata.labels.korifi\.cloudfoundry\.org/updated_at
+      name: Updated At
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: CFDomain is the Schema for the cfdomains API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CFDomainSpec defines the desired state of CFDomain
+            properties:
+              name:
+                description: The domain name. It is required and must conform to RFC
+                  1035
+                type: string
+            required:
+            - name
+            type: object
+          status:
+            description: CFDomainStatus defines the observed state of CFDomain
+            properties:
+              conditions:
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: ObservedGeneration captures the latest generation of
+                  the CFDomain that has been reconciled
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/dependencies/korifi/controllers/crds/korifi.cloudfoundry.org_cforgs.yaml
+++ b/dependencies/korifi/controllers/crds/korifi.cloudfoundry.org_cforgs.yaml
@@ -1,0 +1,136 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  name: cforgs.korifi.cloudfoundry.org
+spec:
+  group: korifi.cloudfoundry.org
+  names:
+    kind: CFOrg
+    listKind: CFOrgList
+    plural: cforgs
+    singular: cforg
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.labels.korifi\.cloudfoundry\.org/created_at
+      name: Created At
+      type: string
+    - jsonPath: .metadata.labels.korifi\.cloudfoundry\.org/updated_at
+      name: Updated At
+      type: string
+    - jsonPath: .spec.displayName
+      name: Display Name
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: CFOrg is the Schema for the cforgs API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CFOrgSpec defines the desired state of CFOrg
+            properties:
+              displayName:
+                description: The mutable, user-friendly name of the CFOrg. Unlike
+                  metadata.name, the user can change this field.
+                pattern: ^[[:alnum:][:punct:][:print:]]+$
+                type: string
+            required:
+            - displayName
+            type: object
+          status:
+            description: CFOrgStatus defines the observed state of CFOrg
+            properties:
+              conditions:
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              guid:
+                type: string
+              observedGeneration:
+                description: ObservedGeneration captures the latest generation of
+                  the CFOrg that has been reconciled
+                format: int64
+                type: integer
+            required:
+            - guid
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/dependencies/korifi/controllers/crds/korifi.cloudfoundry.org_cfpackages.yaml
+++ b/dependencies/korifi/controllers/crds/korifi.cloudfoundry.org_cfpackages.yaml
@@ -1,0 +1,188 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  name: cfpackages.korifi.cloudfoundry.org
+spec:
+  group: korifi.cloudfoundry.org
+  names:
+    kind: CFPackage
+    listKind: CFPackageList
+    plural: cfpackages
+    singular: cfpackage
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.appRef.name
+      name: AppGUID
+      type: string
+    - jsonPath: .metadata.labels.korifi\.cloudfoundry\.org/created_at
+      name: Created At
+      type: string
+    - jsonPath: .metadata.labels.korifi\.cloudfoundry\.org/updated_at
+      name: Updated At
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='Ready')].status
+      name: Ready
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: CFPackage is the Schema for the cfpackages API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CFPackageSpec defines the desired state of CFPackage
+            properties:
+              appRef:
+                description: Reference the CFApp that owns this package. The CFApp
+                  must be in the same namespace.
+                properties:
+                  name:
+                    default: ""
+                    description: |-
+                      Name of the referent.
+                      This field is effectively required, but due to backwards compatibility is
+                      allowed to be empty. Instances of this type with an empty value here are
+                      almost certainly wrong.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              source:
+                description: Contains the details for the source image (e.g. its bits)
+                properties:
+                  registry:
+                    description: registry (i.e an OCI image in a registry that contains
+                      application source)
+                    properties:
+                      image:
+                        description: The location of the source image
+                        type: string
+                      imagePullSecrets:
+                        description: A list of secrets required to pull the image
+                          from its repository
+                        items:
+                          description: |-
+                            LocalObjectReference contains enough information to let you locate the
+                            referenced object inside the same namespace.
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        type: array
+                    required:
+                    - image
+                    type: object
+                required:
+                - registry
+                type: object
+              type:
+                description: The package type. Allowed values are "bits" and "docker".
+                enum:
+                - bits
+                - docker
+                type: string
+            required:
+            - appRef
+            - type
+            type: object
+          status:
+            description: CFPackageStatus defines the observed state of CFPackage
+            properties:
+              conditions:
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: ObservedGeneration captures the latest generation of
+                  the CFPackage that has been reconciled
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/dependencies/korifi/controllers/crds/korifi.cloudfoundry.org_cfprocesses.yaml
+++ b/dependencies/korifi/controllers/crds/korifi.cloudfoundry.org_cfprocesses.yaml
@@ -1,0 +1,230 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  name: cfprocesses.korifi.cloudfoundry.org
+spec:
+  group: korifi.cloudfoundry.org
+  names:
+    kind: CFProcess
+    listKind: CFProcessList
+    plural: cfprocesses
+    singular: cfprocess
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.labels.korifi\.cloudfoundry\.org/created_at
+      name: Created At
+      type: string
+    - jsonPath: .metadata.labels.korifi\.cloudfoundry\.org/updated_at
+      name: Updated At
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: CFProcess is the Schema for the cfprocesses API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CFProcessSpec defines the desired state of CFProcess
+            properties:
+              appRef:
+                description: A reference to the CFApp that owns this CFProcess. The
+                  CFApp must be in the same namespace.
+                properties:
+                  name:
+                    default: ""
+                    description: |-
+                      Name of the referent.
+                      This field is effectively required, but due to backwards compatibility is
+                      allowed to be empty. Instances of this type with an empty value here are
+                      almost certainly wrong.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              command:
+                description: Command string used to run this process on the app image.
+                  This is analogous to command in k8s and ENTRYPOINT in Docker
+                type: string
+              desiredInstances:
+                description: The desired number of replicas to deploy
+                format: int32
+                type: integer
+              detectedCommand:
+                description: The default command for this process as defined by the
+                  build. This field is ignored when the Command field is set
+                type: string
+              diskQuotaMB:
+                description: The disk limit in MiB
+                format: int64
+                type: integer
+              healthCheck:
+                description: Used to build the Liveness and Readiness Probes for the
+                  process' AppWorkload.
+                properties:
+                  data:
+                    description: The input parameters for the liveness and readiness
+                      probes in kubernetes
+                    properties:
+                      httpEndpoint:
+                        description: The http endpoint to use with "http" healthchecks
+                        type: string
+                      invocationTimeoutSeconds:
+                        format: int32
+                        type: integer
+                      timeoutSeconds:
+                        format: int32
+                        type: integer
+                    required:
+                    - invocationTimeoutSeconds
+                    - timeoutSeconds
+                    type: object
+                  type:
+                    description: |-
+                      The type of Health Check the App process will use
+                      Valid values are "http", "port", and "process".
+                      For processType "web", the default type is "port". For all other processes, the default is "process".
+                    enum:
+                    - http
+                    - port
+                    - process
+                    - ""
+                    type: string
+                required:
+                - data
+                - type
+                type: object
+              memoryMB:
+                description: The memory limit in MiB
+                format: int64
+                type: integer
+              ports:
+                description: |-
+                  The ports to expose
+                  Deprecated: No longer used
+                items:
+                  format: int32
+                  type: integer
+                type: array
+              processType:
+                description: The name of the process within the CFApp (e.g. "web")
+                type: string
+            required:
+            - appRef
+            - diskQuotaMB
+            - healthCheck
+            - memoryMB
+            - processType
+            type: object
+          status:
+            description: CFProcessStatus defines the observed state of CFProcess
+            properties:
+              actualInstances:
+                format: int32
+                type: integer
+              conditions:
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              instancesStatus:
+                additionalProperties:
+                  properties:
+                    state:
+                      description: The state of the instance
+                      enum:
+                      - DOWN
+                      - CRASHED
+                      - STARTING
+                      - RUNNING
+                      type: string
+                    timestamp:
+                      description: The time the instance got into this status; nil
+                        if unknown
+                      format: date-time
+                      type: string
+                  required:
+                  - state
+                  type: object
+                type: object
+              observedGeneration:
+                description: ObservedGeneration captures the latest generation of
+                  the CFProcess that has been reconciled
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/dependencies/korifi/controllers/crds/korifi.cloudfoundry.org_cfroutes.yaml
+++ b/dependencies/korifi/controllers/crds/korifi.cloudfoundry.org_cfroutes.yaml
@@ -1,0 +1,292 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  name: cfroutes.korifi.cloudfoundry.org
+spec:
+  group: korifi.cloudfoundry.org
+  names:
+    kind: CFRoute
+    listKind: CFRouteList
+    plural: cfroutes
+    singular: cfroute
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.uri
+      name: URI
+      type: string
+    - jsonPath: .metadata.labels.korifi\.cloudfoundry\.org/created_at
+      name: Created At
+      type: string
+    - jsonPath: .metadata.labels.korifi\.cloudfoundry\.org/updated_at
+      name: Updated At
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .metadata.annotations.korifi\.cloudfoundry\.org/app-guids
+      name: AppGUIDs
+      priority: 1
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: CFRoute is the Schema for the cfroutes API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CFRouteSpec defines the desired state of CFRoute
+            properties:
+              destinations:
+                description: Destinations are optional. A route can exist without
+                  any destinations, independently of any CFApps
+                items:
+                  description: Destination defines a target for a CFRoute, does not
+                    carry meaning outside of a CF context
+                  properties:
+                    appRef:
+                      description: A required reference to the CFApp that will receive
+                        traffic. The CFApp must be in the same namespace
+                      properties:
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    guid:
+                      description: A unique identifier for this route destination.
+                        Required to support CF V3 Destination endpoints
+                      type: string
+                    port:
+                      description: |-
+                        The port to use for the destination. Port is optional, and defaults to
+                        either the droplet port, or 8080 if no ports are available in the
+                        droplet
+                      format: int32
+                      type: integer
+                    processType:
+                      description: The process type on the CFApp app which will receive
+                        traffic
+                      type: string
+                    protocol:
+                      description: Protocol is optional, when set must be "http1"
+                      enum:
+                      - http1
+                      type: string
+                  required:
+                  - appRef
+                  - guid
+                  - processType
+                  type: object
+                type: array
+              domainRef:
+                description: A reference to the CFDomain this CFRoute is assigned
+                  to, including name and namespace
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                    type: string
+                  resourceVersion:
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                    type: string
+                  uid:
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              host:
+                description: |-
+                  The subdomain of the route within the domain. Host is optional and defaults to empty.
+                  When the host is empty, then the name of the app will be used
+                type: string
+              path:
+                description: Path is optional, defaults to empty
+                type: string
+              protocol:
+                description: Protocol is optional and defaults to http. Currently
+                  only http is supported
+                enum:
+                - http
+                - tcp
+                type: string
+            required:
+            - domainRef
+            type: object
+          status:
+            description: CFRouteStatus defines the observed state of CFRoute
+            properties:
+              conditions:
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              destinations:
+                description: The observed state of the destinations. This is mainly
+                  used to record the target port of the underlying service
+                items:
+                  description: Destination defines a target for a CFRoute, does not
+                    carry meaning outside of a CF context
+                  properties:
+                    appRef:
+                      description: A required reference to the CFApp that will receive
+                        traffic. The CFApp must be in the same namespace
+                      properties:
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    guid:
+                      description: A unique identifier for this route destination.
+                        Required to support CF V3 Destination endpoints
+                      type: string
+                    port:
+                      description: |-
+                        The port to use for the destination. Port is optional, and defaults to
+                        either the droplet port, or 8080 if no ports are available in the
+                        droplet
+                      format: int32
+                      type: integer
+                    processType:
+                      description: The process type on the CFApp app which will receive
+                        traffic
+                      type: string
+                    protocol:
+                      description: Protocol is optional, when set must be "http1"
+                      enum:
+                      - http1
+                      type: string
+                  required:
+                  - appRef
+                  - guid
+                  - processType
+                  type: object
+                type: array
+              fqdn:
+                description: The fully-qualified domain name for the route
+                type: string
+              observedGeneration:
+                description: ObservedGeneration captures the latest generation of
+                  the CFRoute that has been reconciled
+                format: int64
+                type: integer
+              uri:
+                description: The URI (FQDN + path) for the route
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/dependencies/korifi/controllers/crds/korifi.cloudfoundry.org_cfsecuritygroups.yaml
+++ b/dependencies/korifi/controllers/crds/korifi.cloudfoundry.org_cfsecuritygroups.yaml
@@ -1,0 +1,168 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  name: cfsecuritygroups.korifi.cloudfoundry.org
+spec:
+  group: korifi.cloudfoundry.org
+  names:
+    kind: CFSecurityGroup
+    listKind: CFSecurityGroupList
+    plural: cfsecuritygroups
+    singular: cfsecuritygroup
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.labels.korifi\.cloudfoundry\.org/created_at
+      name: Created At
+      type: string
+    - jsonPath: .metadata.labels.korifi\.cloudfoundry\.org/updated_at
+      name: Updated At
+      type: string
+    - jsonPath: .spec.displayName
+      name: DisplayName
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              displayName:
+                type: string
+              globallyEnabled:
+                description: //+kubebuilder:validation:Optional
+                properties:
+                  running:
+                    type: boolean
+                  staging:
+                    type: boolean
+                required:
+                - running
+                - staging
+                type: object
+              rules:
+                items:
+                  properties:
+                    code:
+                      type: integer
+                    description:
+                      type: string
+                    destination:
+                      type: string
+                    log:
+                      type: boolean
+                    ports:
+                      type: string
+                    protocol:
+                      type: string
+                    type:
+                      type: integer
+                  required:
+                  - destination
+                  - protocol
+                  type: object
+                type: array
+              spaces:
+                additionalProperties:
+                  properties:
+                    running:
+                      type: boolean
+                    staging:
+                      type: boolean
+                  required:
+                  - running
+                  - staging
+                  type: object
+                description: //+kubebuilder:validation:Optional
+                type: object
+            required:
+            - displayName
+            - rules
+            type: object
+          status:
+            properties:
+              conditions:
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/dependencies/korifi/controllers/crds/korifi.cloudfoundry.org_cfservicebindings.yaml
+++ b/dependencies/korifi/controllers/crds/korifi.cloudfoundry.org_cfservicebindings.yaml
@@ -1,0 +1,254 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  name: cfservicebindings.korifi.cloudfoundry.org
+spec:
+  group: korifi.cloudfoundry.org
+  names:
+    kind: CFServiceBinding
+    listKind: CFServiceBindingList
+    plural: cfservicebindings
+    singular: cfservicebinding
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.labels.korifi\.cloudfoundry\.org/created_at
+      name: Created At
+      type: string
+    - jsonPath: .metadata.labels.korifi\.cloudfoundry\.org/updated_at
+      name: Updated At
+      type: string
+    - jsonPath: .spec.displayName
+      name: Display Name
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: CFServiceBinding is the Schema for the cfservicebindings API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CFServiceBindingSpec defines the desired state of CFServiceBinding
+            properties:
+              appRef:
+                description: A reference to the CFApp that owns this service binding.
+                  The CFApp must be in the same namespace
+                properties:
+                  name:
+                    default: ""
+                    description: |-
+                      Name of the referent.
+                      This field is effectively required, but due to backwards compatibility is
+                      allowed to be empty. Instances of this type with an empty value here are
+                      almost certainly wrong.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              displayName:
+                description: The mutable, user-friendly name of the service binding.
+                  Unlike metadata.name, the user can change this field
+                type: string
+              parameters:
+                description: |-
+                  A reference to the secret that contains the service binding parameters.
+                  Only makes sense for bindings to managed service instances
+                properties:
+                  name:
+                    default: ""
+                    description: |-
+                      Name of the referent.
+                      This field is effectively required, but due to backwards compatibility is
+                      allowed to be empty. Instances of this type with an empty value here are
+                      almost certainly wrong.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              service:
+                description: The Service this binding uses. When created by the korifi
+                  API, this will refer to a CFServiceInstance
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                    type: string
+                  resourceVersion:
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                    type: string
+                  uid:
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              type:
+                description: The type of the binding. There are two possible values
+                  - "key" or "app"
+                enum:
+                - app
+                - key
+                type: string
+            required:
+            - appRef
+            - parameters
+            - service
+            - type
+            type: object
+          status:
+            description: CFServiceBindingStatus defines the observed state of CFServiceBinding
+            properties:
+              conditions:
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              envSecretRef:
+                description: |-
+                  A reference to the Secret containing the binding credentials in json
+                  format. This secret is going to become a part of the VCAP_SERVCIES env var
+                  on the application container. For bindings to user-provided services
+                  this refers to the credentials secret from the service instance. For
+                  managed services the secret contains the credentials object returned by
+                  the broker when binding to a service instance
+                properties:
+                  name:
+                    default: ""
+                    description: |-
+                      Name of the referent.
+                      This field is effectively required, but due to backwards compatibility is
+                      allowed to be empty. Instances of this type with an empty value here are
+                      almost certainly wrong.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              mountSecretRef:
+                description: |-
+                  A reference to the Secret containing the binding Credentials in
+                  [servicebinding.io](https://servicebinding.io/spec/core/1.1.0/) format.
+                  The credentials in this secrets are going to be mounted to the app
+                  container filesystem
+                properties:
+                  name:
+                    default: ""
+                    description: |-
+                      Name of the referent.
+                      This field is effectively required, but due to backwards compatibility is
+                      allowed to be empty. Instances of this type with an empty value here are
+                      almost certainly wrong.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              observedGeneration:
+                description: ObservedGeneration captures the latest generation of
+                  the CFServiceBinding that has been reconciled
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/dependencies/korifi/controllers/crds/korifi.cloudfoundry.org_cfservicebrokers.yaml
+++ b/dependencies/korifi/controllers/crds/korifi.cloudfoundry.org_cfservicebrokers.yaml
@@ -1,0 +1,151 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  name: cfservicebrokers.korifi.cloudfoundry.org
+spec:
+  group: korifi.cloudfoundry.org
+  names:
+    kind: CFServiceBroker
+    listKind: CFServiceBrokerList
+    plural: cfservicebrokers
+    singular: cfservicebroker
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.labels.korifi\.cloudfoundry\.org/created_at
+      name: Created At
+      type: string
+    - jsonPath: .metadata.labels.korifi\.cloudfoundry\.org/updated_at
+      name: Updated At
+      type: string
+    - jsonPath: .spec.name
+      name: Display Name
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              credentials:
+                description: |-
+                  LocalObjectReference contains enough information to let you locate the
+                  referenced object inside the same namespace.
+                properties:
+                  name:
+                    default: ""
+                    description: |-
+                      Name of the referent.
+                      This field is effectively required, but due to backwards compatibility is
+                      allowed to be empty. Instances of this type with an empty value here are
+                      almost certainly wrong.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              name:
+                type: string
+              url:
+                type: string
+            required:
+            - credentials
+            - name
+            - url
+            type: object
+          status:
+            properties:
+              conditions:
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              credentialsObservedVersion:
+                description: |-
+                  ObservedGeneration captures the latest version of the spec.Credentials.Name secret that has been reconciled
+                  This will ensure that interested contollers are notified on broker credentials change
+                type: string
+              observedGeneration:
+                description: ObservedGeneration captures the latest generation of
+                  the CFServiceBroker that has been reconciled
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/dependencies/korifi/controllers/crds/korifi.cloudfoundry.org_cfserviceinstances.yaml
+++ b/dependencies/korifi/controllers/crds/korifi.cloudfoundry.org_cfserviceinstances.yaml
@@ -1,0 +1,230 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  name: cfserviceinstances.korifi.cloudfoundry.org
+spec:
+  group: korifi.cloudfoundry.org
+  names:
+    kind: CFServiceInstance
+    listKind: CFServiceInstanceList
+    plural: cfserviceinstances
+    singular: cfserviceinstance
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.labels.korifi\.cloudfoundry\.org/created_at
+      name: Created At
+      type: string
+    - jsonPath: .metadata.labels.korifi\.cloudfoundry\.org/updated_at
+      name: Updated At
+      type: string
+    - jsonPath: .spec.displayName
+      name: Display Name
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: CFServiceInstance is the Schema for the cfserviceinstances API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CFServiceInstanceSpec defines the desired state of CFServiceInstance
+            properties:
+              displayName:
+                description: The mutable, user-friendly name of the service instance.
+                  Unlike metadata.name, the user can change this field
+                type: string
+              parameters:
+                description: |-
+                  LocalObjectReference contains enough information to let you locate the
+                  referenced object inside the same namespace.
+                properties:
+                  name:
+                    default: ""
+                    description: |-
+                      Name of the referent.
+                      This field is effectively required, but due to backwards compatibility is
+                      allowed to be empty. Instances of this type with an empty value here are
+                      almost certainly wrong.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              planGuid:
+                type: string
+              secretName:
+                description: Name of a secret containing the service credentials.
+                  The Secret must be in the same namespace
+                type: string
+              serviceLabel:
+                description: |-
+                  Service label to use when adding this instance to VCAP_SERVICES. If not
+                  set, the service instance Type would be used. For managed services the
+                  value is defaulted to the offering name
+                type: string
+              tags:
+                description: Tags are used by apps to identify service instances
+                items:
+                  type: string
+                type: array
+              type:
+                description: Type of the Service Instance. Must be `user-provided`
+                  or `managed`
+                enum:
+                - user-provided
+                - managed
+                type: string
+            required:
+            - displayName
+            - planGuid
+            - secretName
+            - type
+            type: object
+          status:
+            description: CFServiceInstanceStatus defines the observed state of CFServiceInstance
+            properties:
+              conditions:
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              credentials:
+                description: |-
+                  A reference to the service instance secret containing the credentials
+                  (derived from spec.secretName).
+                properties:
+                  name:
+                    default: ""
+                    description: |-
+                      Name of the referent.
+                      This field is effectively required, but due to backwards compatibility is
+                      allowed to be empty. Instances of this type with an empty value here are
+                      almost certainly wrong.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              credentialsObservedVersion:
+                description: |-
+                  ObservedGeneration captures the latest version of the spec.secretName that has been reconciled
+                  This will ensure that interested contollers are notified on instance credentials change
+                type: string
+              lastOperation:
+                properties:
+                  description:
+                    type: string
+                  state:
+                    enum:
+                    - initial
+                    - in progress
+                    - succeeded
+                    - failed
+                    type: string
+                  type:
+                    enum:
+                    - create
+                    - update
+                    - delete
+                    type: string
+                required:
+                - state
+                - type
+                type: object
+              maintenanceInfo:
+                description: The service instance maintenance info. Only makes seense
+                  for managed service instances
+                properties:
+                  version:
+                    type: string
+                required:
+                - version
+                type: object
+              observedGeneration:
+                description: ObservedGeneration captures the latest generation of
+                  the CFServiceInstance that has been reconciled
+                format: int64
+                type: integer
+              upgradeAvailable:
+                description: True if there is an upgrade available for for the service
+                  instance (i.e. the plan has a new version). Only makes seense for
+                  managed service instances
+                type: boolean
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/dependencies/korifi/controllers/crds/korifi.cloudfoundry.org_cfserviceofferings.yaml
+++ b/dependencies/korifi/controllers/crds/korifi.cloudfoundry.org_cfserviceofferings.yaml
@@ -1,0 +1,113 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  name: cfserviceofferings.korifi.cloudfoundry.org
+spec:
+  group: korifi.cloudfoundry.org
+  names:
+    kind: CFServiceOffering
+    listKind: CFServiceOfferingList
+    plural: cfserviceofferings
+    singular: cfserviceoffering
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.labels.korifi\.cloudfoundry\.org/created_at
+      name: Created At
+      type: string
+    - jsonPath: .metadata.labels.korifi\.cloudfoundry\.org/updated_at
+      name: Updated At
+      type: string
+    - jsonPath: .spec.name
+      name: Display Name
+      type: string
+    - jsonPath: .spec.description
+      name: Description
+      type: string
+    - jsonPath: .spec.available
+      name: Available
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: CFServiceOffering is the Schema for the cfserviceofferings API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CFServiceOfferingSpec defines the desired state of CFServiceOffering
+            properties:
+              brokerCatalog:
+                properties:
+                  features:
+                    properties:
+                      allowContextUpdates:
+                        type: boolean
+                      bindable:
+                        type: boolean
+                      bindingsRetrievable:
+                        type: boolean
+                      instancesRetrievable:
+                        type: boolean
+                      planUpdateable:
+                        type: boolean
+                    required:
+                    - allowContextUpdates
+                    - bindable
+                    - bindingsRetrievable
+                    - instancesRetrievable
+                    - planUpdateable
+                    type: object
+                  id:
+                    type: string
+                  metadata:
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                required:
+                - features
+                - id
+                type: object
+              description:
+                type: string
+              documentationUrl:
+                type: string
+              name:
+                type: string
+              requires:
+                items:
+                  type: string
+                type: array
+              tags:
+                items:
+                  type: string
+                type: array
+            required:
+            - brokerCatalog
+            - description
+            - name
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources: {}

--- a/dependencies/korifi/controllers/crds/korifi.cloudfoundry.org_cfserviceplans.yaml
+++ b/dependencies/korifi/controllers/crds/korifi.cloudfoundry.org_cfserviceplans.yaml
@@ -1,0 +1,153 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  name: cfserviceplans.korifi.cloudfoundry.org
+spec:
+  group: korifi.cloudfoundry.org
+  names:
+    kind: CFServicePlan
+    listKind: CFServicePlanList
+    plural: cfserviceplans
+    singular: cfserviceplan
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.labels.korifi\.cloudfoundry\.org/created_at
+      name: Created At
+      type: string
+    - jsonPath: .metadata.labels.korifi\.cloudfoundry\.org/updated_at
+      name: Updated At
+      type: string
+    - jsonPath: .spec.name
+      name: Display Name
+      type: string
+    - jsonPath: .spec.available
+      name: Available
+      type: string
+    - jsonPath: .spec.free
+      name: Free
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              brokerCatalog:
+                properties:
+                  features:
+                    properties:
+                      bindable:
+                        type: boolean
+                      planUpdateable:
+                        type: boolean
+                    required:
+                    - bindable
+                    - planUpdateable
+                    type: object
+                  id:
+                    type: string
+                  metadata:
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                required:
+                - id
+                type: object
+              description:
+                type: string
+              free:
+                type: boolean
+              maintenanceInfo:
+                properties:
+                  version:
+                    type: string
+                required:
+                - version
+                type: object
+              name:
+                type: string
+              schemas:
+                properties:
+                  serviceBinding:
+                    properties:
+                      create:
+                        properties:
+                          parameters:
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
+                    required:
+                    - create
+                    type: object
+                  serviceInstance:
+                    properties:
+                      create:
+                        properties:
+                          parameters:
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
+                      update:
+                        properties:
+                          parameters:
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
+                    required:
+                    - create
+                    - update
+                    type: object
+                required:
+                - serviceBinding
+                - serviceInstance
+                type: object
+              visibility:
+                properties:
+                  organizations:
+                    items:
+                      type: string
+                    type: array
+                  type:
+                    enum:
+                    - admin
+                    - public
+                    - organization
+                    type: string
+                required:
+                - type
+                type: object
+            required:
+            - brokerCatalog
+            - free
+            - maintenanceInfo
+            - name
+            - schemas
+            - visibility
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources: {}

--- a/dependencies/korifi/controllers/crds/korifi.cloudfoundry.org_cfspaces.yaml
+++ b/dependencies/korifi/controllers/crds/korifi.cloudfoundry.org_cfspaces.yaml
@@ -1,0 +1,136 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  name: cfspaces.korifi.cloudfoundry.org
+spec:
+  group: korifi.cloudfoundry.org
+  names:
+    kind: CFSpace
+    listKind: CFSpaceList
+    plural: cfspaces
+    singular: cfspace
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.labels.korifi\.cloudfoundry\.org/created_at
+      name: Created At
+      type: string
+    - jsonPath: .metadata.labels.korifi\.cloudfoundry\.org/updated_at
+      name: Updated At
+      type: string
+    - jsonPath: .spec.displayName
+      name: Display Name
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: CFSpace is the Schema for the cfspaces API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CFSpaceSpec defines the desired state of CFSpace
+            properties:
+              displayName:
+                description: The mutable, user-friendly name of the space. Unlike
+                  metadata.name, the user can change this field
+                pattern: ^[[:alnum:][:punct:][:print:]]+$
+                type: string
+            required:
+            - displayName
+            type: object
+          status:
+            description: CFSpaceStatus defines the observed state of CFSpace
+            properties:
+              conditions:
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              guid:
+                type: string
+              observedGeneration:
+                description: ObservedGeneration captures the latest generation of
+                  the CFSpace that has been reconciled
+                format: int64
+                type: integer
+            required:
+            - guid
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/dependencies/korifi/controllers/crds/korifi.cloudfoundry.org_cftasks.yaml
+++ b/dependencies/korifi/controllers/crds/korifi.cloudfoundry.org_cftasks.yaml
@@ -1,0 +1,165 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  name: cftasks.korifi.cloudfoundry.org
+spec:
+  group: korifi.cloudfoundry.org
+  names:
+    kind: CFTask
+    listKind: CFTaskList
+    plural: cftasks
+    singular: cftask
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.labels.korifi\.cloudfoundry\.org/created_at
+      name: Created At
+      type: string
+    - jsonPath: .metadata.labels.korifi\.cloudfoundry\.org/updated_at
+      name: Updated At
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: CFTask is the Schema for the cftasks API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CFTaskSpec defines the desired state of CFTask
+            properties:
+              appRef:
+                description: A reference to the CFApp containing the code or script
+                  for this CFTask
+                properties:
+                  name:
+                    default: ""
+                    description: |-
+                      Name of the referent.
+                      This field is effectively required, but due to backwards compatibility is
+                      allowed to be empty. Instances of this type with an empty value here are
+                      almost certainly wrong.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              canceled:
+                description: A boolean describing whether the CFTask has been canceled
+                type: boolean
+              command:
+                description: The command used to start the task process
+                type: string
+            type: object
+          status:
+            description: CFTaskStatus defines the observed state of CFTask
+            properties:
+              conditions:
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              diskQuotaMB:
+                format: int64
+                type: integer
+              dropletRef:
+                description: |-
+                  LocalObjectReference contains enough information to let you locate the
+                  referenced object inside the same namespace.
+                properties:
+                  name:
+                    default: ""
+                    description: |-
+                      Name of the referent.
+                      This field is effectively required, but due to backwards compatibility is
+                      allowed to be empty. Instances of this type with an empty value here are
+                      almost certainly wrong.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              memoryMB:
+                format: int64
+                type: integer
+              observedGeneration:
+                description: ObservedGeneration captures the latest generation of
+                  the CFTask that has been reconciled
+                format: int64
+                type: integer
+              sequenceId:
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/dependencies/korifi/controllers/crds/korifi.cloudfoundry.org_runnerinfos.yaml
+++ b/dependencies/korifi/controllers/crds/korifi.cloudfoundry.org_runnerinfos.yaml
@@ -1,0 +1,123 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  name: runnerinfos.korifi.cloudfoundry.org
+spec:
+  group: korifi.cloudfoundry.org
+  names:
+    kind: RunnerInfo
+    listKind: RunnerInfoList
+    plural: runnerinfos
+    singular: runnerinfo
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: RunnerInfo is the Schema for the runnerinfos API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: RunnerInfoSpec defines the desired state of RunnerInfo
+            properties:
+              runnerName:
+                type: string
+            required:
+            - runnerName
+            type: object
+          status:
+            description: RunnerInfoStatus defines the observed state of RunnerInfo
+            properties:
+              capabilities:
+                properties:
+                  rollingDeploy:
+                    type: boolean
+                type: object
+              conditions:
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: ObservedGeneration captures the latest generation of
+                  the RunnerInfo that has been reconciled
+                format: int64
+                type: integer
+            required:
+            - capabilities
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/dependencies/korifi/controllers/crds/korifi.cloudfoundry.org_taskworkloads.yaml
+++ b/dependencies/korifi/controllers/crds/korifi.cloudfoundry.org_taskworkloads.yaml
@@ -1,0 +1,354 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  name: taskworkloads.korifi.cloudfoundry.org
+spec:
+  group: korifi.cloudfoundry.org
+  names:
+    kind: TaskWorkload
+    listKind: TaskWorkloadList
+    plural: taskworkloads
+    singular: taskworkload
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: TaskWorkload is the Schema for the taskworkloads API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TaskWorkloadSpec defines the desired state of TaskWorkload
+            properties:
+              command:
+                items:
+                  type: string
+                type: array
+              env:
+                items:
+                  description: EnvVar represents an environment variable present in
+                    a Container.
+                  properties:
+                    name:
+                      description: |-
+                        Name of the environment variable.
+                        May consist of any printable ASCII characters except '='.
+                      type: string
+                    value:
+                      description: |-
+                        Variable references $(VAR_NAME) are expanded
+                        using the previously defined environment variables in the container and
+                        any service environment variables. If a variable cannot be resolved,
+                        the reference in the input string will be unchanged. Double $$ are reduced
+                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                        "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                        Escaped references will never be expanded, regardless of whether the variable
+                        exists or not.
+                        Defaults to "".
+                      type: string
+                    valueFrom:
+                      description: Source for the environment variable's value. Cannot
+                        be used if value is not empty.
+                      properties:
+                        configMapKeyRef:
+                          description: Selects a key of a ConfigMap.
+                          properties:
+                            key:
+                              description: The key to select.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap or its key
+                                must be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        fieldRef:
+                          description: |-
+                            Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                            spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                          properties:
+                            apiVersion:
+                              description: Version of the schema the FieldPath is
+                                written in terms of, defaults to "v1".
+                              type: string
+                            fieldPath:
+                              description: Path of the field to select in the specified
+                                API version.
+                              type: string
+                          required:
+                          - fieldPath
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        fileKeyRef:
+                          description: |-
+                            FileKeyRef selects a key of the env file.
+                            Requires the EnvFiles feature gate to be enabled.
+                          properties:
+                            key:
+                              description: |-
+                                The key within the env file. An invalid key will prevent the pod from starting.
+                                The keys defined within a source may consist of any printable ASCII characters except '='.
+                                During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                              type: string
+                            optional:
+                              default: false
+                              description: |-
+                                Specify whether the file or its key must be defined. If the file or key
+                                does not exist, then the env var is not published.
+                                If optional is set to true and the specified key does not exist,
+                                the environment variable will not be set in the Pod's containers.
+
+                                If optional is set to false and the specified key does not exist,
+                                an error will be returned during Pod creation.
+                              type: boolean
+                            path:
+                              description: |-
+                                The path within the volume from which to select the file.
+                                Must be relative and may not contain the '..' path or start with '..'.
+                              type: string
+                            volumeName:
+                              description: The name of the volume mount containing
+                                the env file.
+                              type: string
+                          required:
+                          - key
+                          - path
+                          - volumeName
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        resourceFieldRef:
+                          description: |-
+                            Selects a resource of the container: only resources limits and requests
+                            (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                          properties:
+                            containerName:
+                              description: 'Container name: required for volumes,
+                                optional for env vars'
+                              type: string
+                            divisor:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Specifies the output format of the exposed
+                                resources, defaults to "1"
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            resource:
+                              description: 'Required: resource to select'
+                              type: string
+                          required:
+                          - resource
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        secretKeyRef:
+                          description: Selects a key of a secret in the pod's namespace
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
+              image:
+                type: string
+              imagePullSecrets:
+                items:
+                  description: |-
+                    LocalObjectReference contains enough information to let you locate the
+                    referenced object inside the same namespace.
+                  properties:
+                    name:
+                      default: ""
+                      description: |-
+                        Name of the referent.
+                        This field is effectively required, but due to backwards compatibility is
+                        allowed to be empty. Instances of this type with an empty value here are
+                        almost certainly wrong.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      type: string
+                  type: object
+                  x-kubernetes-map-type: atomic
+                type: array
+              resources:
+                description: ResourceRequirements describes the compute resource requirements.
+                properties:
+                  claims:
+                    description: |-
+                      Claims lists the names of resources, defined in spec.resourceClaims,
+                      that are used by this container.
+
+                      This field depends on the
+                      DynamicResourceAllocation feature gate.
+
+                      This field is immutable. It can only be set for containers.
+                    items:
+                      description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                      properties:
+                        name:
+                          description: |-
+                            Name must match the name of one entry in pod.spec.resourceClaims of
+                            the Pod where this field is used. It makes that resource available
+                            inside a container.
+                          type: string
+                        request:
+                          description: |-
+                            Request is the name chosen for a request in the referenced claim.
+                            If empty, everything from the claim is made available, otherwise
+                            only the result of this request.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                  limits:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: |-
+                      Limits describes the maximum amount of compute resources allowed.
+                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    type: object
+                  requests:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: |-
+                      Requests describes the minimum amount of compute resources required.
+                      If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                      otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    type: object
+                type: object
+            required:
+            - command
+            - image
+            type: object
+          status:
+            description: TaskWorkloadStatus defines the observed state of TaskWorkload
+            properties:
+              conditions:
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: ObservedGeneration captures the latest generation of
+                  the TaskWorkload that has been reconciled
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/dependencies/korifi/controllers/deployment.yaml
+++ b/dependencies/korifi/controllers/deployment.yaml
@@ -1,0 +1,95 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: korifi-controllers
+  name: korifi-controllers-controller-manager
+  namespace: {{ .Release.Namespace }}
+spec:
+  replicas: {{ .Values.controllers.replicas | default 1}}
+  selector:
+    matchLabels:
+      app: korifi-controllers
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8080"
+        prometheus.io/scrape: "true"
+        checksum/config: {{ tpl ($.Files.Get "controllers/configmap.yaml") $ | sha256sum }}
+      labels:
+        app: korifi-controllers
+    spec:
+      containers:
+      - name: manager
+        env:
+        - name: CONTROLLERSCONFIG
+          value: /etc/korifi-controllers-config
+        image: {{ .Values.controllers.image }}
+{{- if .Values.debug }}
+        command:
+        - "/dlv"
+        args:
+        - "--listen=:40000"
+        - "--headless=true"
+        - "--api-version=2"
+        - "exec"
+        - "/manager"
+        - "--continue"
+        - "--accept-multiclient"
+        - "--"
+        - "--health-probe-bind-address=:8081"
+        - "--leader-elect"
+{{- else }}
+        args:
+        - --health-probe-bind-address=:8081
+        - --leader-elect
+{{- end }}
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        - containerPort: 8080
+          name: metrics
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        {{- include "korifi.resources" . | indent 8 }}
+        {{- include "korifi.securityContext" . | indent 8 }}
+        volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: cert
+          readOnly: true
+        - mountPath: /etc/korifi-controllers-config
+          name: korifi-controllers-config
+          readOnly: true
+      {{- include "korifi.podSecurityContext" . | indent 6 }}
+      serviceAccountName: korifi-controllers-controller-manager
+{{- if .Values.controllers.nodeSelector }}
+      nodeSelector:
+      {{ toYaml .Values.controllers.nodeSelector | indent 8 }}
+{{- end }}
+{{- if .Values.controllers.tolerations }}
+      tolerations:
+      {{- toYaml .Values.controllers.tolerations | nindent 8 }}
+{{- end }}
+      terminationGracePeriodSeconds: 10
+      volumes:
+      - name: cert
+        secret:
+          defaultMode: 420
+          secretName: {{ .Values.controllers.webhookCertSecret }}
+      - configMap:
+          name: korifi-controllers-config
+        name: korifi-controllers-config

--- a/dependencies/korifi/controllers/ingress-cert.yaml
+++ b/dependencies/korifi/controllers/ingress-cert.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.generateIngressCertificates }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ .Values.controllers.workloadsTLSSecret }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  commonName: \*.{{ .Values.defaultAppDomainName }}
+  dnsNames:
+  - \*.{{ .Values.defaultAppDomainName }}
+  issuerRef:
+    kind: Issuer
+    name: selfsigned-issuer
+  secretName: {{ .Values.controllers.workloadsTLSSecret }}
+{{- end}}

--- a/dependencies/korifi/controllers/manifests.yaml
+++ b/dependencies/korifi/controllers/manifests.yaml
@@ -1,0 +1,509 @@
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: korifi-controllers-mutating-webhook-configuration
+  annotations:
+    cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/{{ .Values.controllers.webhookCertSecret }}'
+webhooks:
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: korifi-controllers-webhook-service
+        namespace: '{{ .Release.Namespace }}'
+        path: /mutate-korifi-cloudfoundry-org-v1alpha1-cfapp
+      caBundle: '{{ include "korifi.webhookCaBundle" (set . "component" "controllers") }}'
+    failurePolicy: Fail
+    name: mcfapp.korifi.cloudfoundry.org
+    rules:
+      - apiGroups:
+          - korifi.cloudfoundry.org
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - cfapps
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: korifi-controllers-webhook-service
+        namespace: '{{ .Release.Namespace }}'
+        path: /mutate-korifi-cloudfoundry-org-v1alpha1-cfprocess
+      caBundle: '{{ include "korifi.webhookCaBundle" (set . "component" "controllers") }}'
+    failurePolicy: Fail
+    name: mcfprocess.korifi.cloudfoundry.org
+    rules:
+      - apiGroups:
+          - korifi.cloudfoundry.org
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - cfprocesses
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: korifi-controllers-webhook-service
+        namespace: '{{ .Release.Namespace }}'
+        path: /mutate-korifi-cloudfoundry-org-v1alpha1-controllers-common-labels
+      caBundle: '{{ include "korifi.webhookCaBundle" (set . "component" "controllers") }}'
+    failurePolicy: Fail
+    name: mcfcommonlabels.korifi.cloudfoundry.org
+    rules:
+      - apiGroups:
+          - korifi.cloudfoundry.org
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - cfapps
+          - cfbuilds
+          - cfdomains
+          - cforgs
+          - cfpackages
+          - cfprocesses
+          - cfroutes
+          - cfsecuritygroups
+          - cfservicebindings
+          - cfservicebrokers
+          - cfserviceinstances
+          - cfserviceofferings
+          - cfserviceplans
+          - cfspaces
+          - cftasks
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: korifi-controllers-webhook-service
+        namespace: '{{ .Release.Namespace }}'
+        path: /mutate-korifi-cloudfoundry-org-v1alpha1-controllers-finalizer
+      caBundle: '{{ include "korifi.webhookCaBundle" (set . "component" "controllers") }}'
+    failurePolicy: Fail
+    name: mcffinalizer.korifi.cloudfoundry.org
+    rules:
+      - apiGroups:
+          - korifi.cloudfoundry.org
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+        resources:
+          - cfapps
+          - cfspaces
+          - cfpackages
+          - cforgs
+          - cfroutes
+          - cfdomains
+          - cfservicebindings
+          - cfserviceinstances
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: korifi-controllers-webhook-service
+        namespace: '{{ .Release.Namespace }}'
+        path: /mutate-korifi-cloudfoundry-org-v1alpha1-controllers-label-indexer
+      caBundle: '{{ include "korifi.webhookCaBundle" (set . "component" "controllers") }}'
+    failurePolicy: Fail
+    name: mcflabelindexer.korifi.cloudfoundry.org
+    rules:
+      - apiGroups:
+          - korifi.cloudfoundry.org
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - cfroutes
+          - cfapps
+          - cfbuilds
+          - cfdomains
+          - cfpackages
+          - cfprocesses
+          - cfservicebindings
+          - cfserviceinstances
+          - cftasks
+          - cforgs
+          - cfspaces
+          - cfserviceofferings
+          - cfserviceplans
+          - cfservicebrokers
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: korifi-controllers-webhook-service
+        namespace: '{{ .Release.Namespace }}'
+        path: /mutate-korifi-cloudfoundry-org-v1alpha1-route-appdestinations
+      caBundle: '{{ include "korifi.webhookCaBundle" (set . "component" "controllers") }}'
+    failurePolicy: Fail
+    name: mcfrouteappdestinations.korifi.cloudfoundry.org
+    rules:
+      - apiGroups:
+          - korifi.cloudfoundry.org
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - cfroutes
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: korifi-controllers-webhook-service
+        namespace: '{{ .Release.Namespace }}'
+        path: /mutate-korifi-cloudfoundry-org-v1alpha1-all-version
+      caBundle: '{{ include "korifi.webhookCaBundle" (set . "component" "controllers") }}'
+    failurePolicy: Fail
+    name: mcfversion.korifi.cloudfoundry.org
+    rules:
+      - apiGroups:
+          - korifi.cloudfoundry.org
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - cforgs
+          - cfspaces
+          - builderinfos
+          - cfdomains
+          - cfserviceinstances
+          - cfapps
+          - cfpackages
+          - cftasks
+          - cfprocesses
+          - cfbuilds
+          - cfroutes
+          - cfservicebindings
+          - taskworkloads
+          - appworkloads
+          - buildworkloads
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: korifi-controllers-webhook-service
+        namespace: '{{ .Release.Namespace }}'
+        path: /mutate-korifi-cloudfoundry-org-v1alpha1-cfapp-apprev
+      caBundle: '{{ include "korifi.webhookCaBundle" (set . "component" "controllers") }}'
+    failurePolicy: Fail
+    name: mcfapprev.korifi.cloudfoundry.org
+    rules:
+      - apiGroups:
+          - korifi.cloudfoundry.org
+        apiVersions:
+          - v1alpha1
+        operations:
+          - UPDATE
+        resources:
+          - cfapps
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: korifi-controllers-webhook-service
+        namespace: '{{ .Release.Namespace }}'
+        path: /mutate-korifi-cloudfoundry-org-v1alpha1-cftask
+      caBundle: '{{ include "korifi.webhookCaBundle" (set . "component" "controllers") }}'
+    failurePolicy: Fail
+    name: mcftask.korifi.cloudfoundry.org
+    rules:
+      - apiGroups:
+          - korifi.cloudfoundry.org
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - cftasks/status
+    sideEffects: None
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: korifi-controllers-validating-webhook-configuration
+  annotations:
+    cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/{{ .Values.controllers.webhookCertSecret }}'
+webhooks:
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: korifi-controllers-webhook-service
+        namespace: '{{ .Release.Namespace }}'
+        path: /validate-korifi-cloudfoundry-org-v1alpha1-cfdomain
+      caBundle: '{{ include "korifi.webhookCaBundle" (set . "component" "controllers") }}'
+    failurePolicy: Fail
+    name: vcfdomain.korifi.cloudfoundry.org
+    rules:
+      - apiGroups:
+          - korifi.cloudfoundry.org
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - cfdomains
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: korifi-controllers-webhook-service
+        namespace: '{{ .Release.Namespace }}'
+        path: /validate-korifi-cloudfoundry-org-v1alpha1-cfroute
+      caBundle: '{{ include "korifi.webhookCaBundle" (set . "component" "controllers") }}'
+    failurePolicy: Fail
+    name: vcfroute.korifi.cloudfoundry.org
+    rules:
+      - apiGroups:
+          - korifi.cloudfoundry.org
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+          - DELETE
+        resources:
+          - cfroutes
+    sideEffects: NoneOnDryRun
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: korifi-controllers-webhook-service
+        namespace: '{{ .Release.Namespace }}'
+        path: /validate-korifi-cloudfoundry-org-v1alpha1-cfsecuritygroup
+      caBundle: '{{ include "korifi.webhookCaBundle" (set . "component" "controllers") }}'
+    failurePolicy: Fail
+    name: vcfsecuritygroup.korifi.cloudfoundry.org
+    rules:
+      - apiGroups:
+          - korifi.cloudfoundry.org
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+          - DELETE
+        resources:
+          - cfsecuritygroups
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: korifi-controllers-webhook-service
+        namespace: '{{ .Release.Namespace }}'
+        path: /validate-korifi-cloudfoundry-org-v1alpha1-cfservicebinding
+      caBundle: '{{ include "korifi.webhookCaBundle" (set . "component" "controllers") }}'
+    failurePolicy: Fail
+    name: vcfservicebinding.korifi.cloudfoundry.org
+    rules:
+      - apiGroups:
+          - korifi.cloudfoundry.org
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+          - DELETE
+        resources:
+          - cfservicebindings
+    sideEffects: NoneOnDryRun
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: korifi-controllers-webhook-service
+        namespace: '{{ .Release.Namespace }}'
+        path: /validate-korifi-cloudfoundry-org-v1alpha1-cfservicebroker
+      caBundle: '{{ include "korifi.webhookCaBundle" (set . "component" "controllers") }}'
+    failurePolicy: Fail
+    name: vcfservicebroker.korifi.cloudfoundry.org
+    rules:
+      - apiGroups:
+          - korifi.cloudfoundry.org
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+          - DELETE
+        resources:
+          - cfservicebrokers
+    sideEffects: NoneOnDryRun
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: korifi-controllers-webhook-service
+        namespace: '{{ .Release.Namespace }}'
+        path: /validate-korifi-cloudfoundry-org-v1alpha1-cfserviceinstance
+      caBundle: '{{ include "korifi.webhookCaBundle" (set . "component" "controllers") }}'
+    failurePolicy: Fail
+    name: vcfserviceinstance.korifi.cloudfoundry.org
+    rules:
+      - apiGroups:
+          - korifi.cloudfoundry.org
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+          - DELETE
+        resources:
+          - cfserviceinstances
+    sideEffects: NoneOnDryRun
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: korifi-controllers-webhook-service
+        namespace: '{{ .Release.Namespace }}'
+        path: /validate-korifi-cloudfoundry-org-v1alpha1-cfapp
+      caBundle: '{{ include "korifi.webhookCaBundle" (set . "component" "controllers") }}'
+    failurePolicy: Fail
+    name: vcfapp.korifi.cloudfoundry.org
+    rules:
+      - apiGroups:
+          - korifi.cloudfoundry.org
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+          - DELETE
+        resources:
+          - cfapps
+    sideEffects: NoneOnDryRun
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: korifi-controllers-webhook-service
+        namespace: '{{ .Release.Namespace }}'
+        path: /validate-korifi-cloudfoundry-org-v1alpha1-cforg
+      caBundle: '{{ include "korifi.webhookCaBundle" (set . "component" "controllers") }}'
+    failurePolicy: Fail
+    name: vcforg.korifi.cloudfoundry.org
+    rules:
+      - apiGroups:
+          - korifi.cloudfoundry.org
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+          - DELETE
+        resources:
+          - cforgs
+    sideEffects: NoneOnDryRun
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: korifi-controllers-webhook-service
+        namespace: '{{ .Release.Namespace }}'
+        path: /validate-korifi-cloudfoundry-org-v1alpha1-cfpackage
+      caBundle: '{{ include "korifi.webhookCaBundle" (set . "component" "controllers") }}'
+    failurePolicy: Fail
+    name: vcfpackage.korifi.cloudfoundry.org
+    rules:
+      - apiGroups:
+          - korifi.cloudfoundry.org
+        apiVersions:
+          - v1alpha1
+        operations:
+          - UPDATE
+        resources:
+          - cfpackages
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: korifi-controllers-webhook-service
+        namespace: '{{ .Release.Namespace }}'
+        path: /validate-korifi-cloudfoundry-org-v1alpha1-cfspace
+      caBundle: '{{ include "korifi.webhookCaBundle" (set . "component" "controllers") }}'
+    failurePolicy: Fail
+    name: vcfspace.korifi.cloudfoundry.org
+    rules:
+      - apiGroups:
+          - korifi.cloudfoundry.org
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+          - DELETE
+        resources:
+          - cfspaces
+    sideEffects: NoneOnDryRun
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: korifi-controllers-webhook-service
+        namespace: '{{ .Release.Namespace }}'
+        path: /validate-korifi-cloudfoundry-org-v1alpha1-cftask
+      caBundle: '{{ include "korifi.webhookCaBundle" (set . "component" "controllers") }}'
+    failurePolicy: Fail
+    name: vcftask.korifi.cloudfoundry.org
+    rules:
+      - apiGroups:
+          - korifi.cloudfoundry.org
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - cftasks
+          - cftasks/status
+    sideEffects: None

--- a/dependencies/korifi/controllers/post-install-app-domain.yaml
+++ b/dependencies/korifi/controllers/post-install-app-domain.yaml
@@ -1,0 +1,52 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  annotations:
+    # This is what defines this resource as a hook. Without this line, the
+    # job is considered part of the release.
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+  name: create-app-domain
+  namespace: {{ .Release.Namespace }}
+spec:
+  template:
+    metadata:
+      name: create-app-domain
+      labels:
+        app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+        app.kubernetes.io/instance: {{ .Release.Name | quote }}
+        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    spec:
+      serviceAccountName: korifi-controllers-controller-manager
+      restartPolicy: Never
+      {{- include "korifi.podSecurityContext" . | indent 6 }}
+      containers:
+      - name: post-install-create-app-domain
+        image: {{ .Values.helm.hooksImage }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          runAsUser: 1000
+          capabilities:
+            drop:
+            - ALL
+          seccompProfile:
+            type: RuntimeDefault
+        command:
+        - sh
+        - -c
+        - |
+          cat <<EOF | kubectl -n {{ .Values.rootNamespace }} apply -f -
+          apiVersion: korifi.cloudfoundry.org/v1alpha1
+          kind: CFDomain
+          metadata:
+            name: default-domain
+          spec:
+            name: {{ .Values.defaultAppDomainName }}
+          EOF

--- a/dependencies/korifi/controllers/rbac.yaml
+++ b/dependencies/korifi/controllers/rbac.yaml
@@ -1,0 +1,81 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: korifi-controllers-controller-manager
+  namespace: {{ .Release.Namespace }}
+  {{- if .Values.eksContainerRegistryRoleARN }}
+  annotations:
+    eks.amazonaws.com/role-arn: {{ .Values.eksContainerRegistryRoleARN }}
+  {{- end }}
+imagePullSecrets:
+{{- range .Values.systemImagePullSecrets }}
+- name: {{ . | quote }}
+{{- end }}
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: korifi-controllers-leader-election-role
+  namespace: {{ .Release.Namespace }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: korifi-controllers-leader-election-rolebinding
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: korifi-controllers-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: korifi-controllers-controller-manager
+  namespace: {{ .Release.Namespace }}
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: korifi-controllers-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: korifi-controllers-manager-role
+subjects:
+- kind: ServiceAccount
+  name: korifi-controllers-controller-manager
+  namespace: {{ .Release.Namespace }}

--- a/dependencies/korifi/controllers/role.yaml
+++ b/dependencies/korifi/controllers/role.yaml
@@ -1,0 +1,260 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: korifi-controllers-manager-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  - secrets
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - create
+  - delete
+  - deletecollection
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - httproutes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - httproutes/status
+  verbs:
+  - get
+- apiGroups:
+  - korifi.cloudfoundry.org
+  resources:
+  - appworkloads
+  - builderinfos
+  - buildworkloads
+  - cfbuilds
+  - cforgs
+  - cfpackages
+  - cfprocesses
+  - cfroutes
+  - cfservicebindings
+  - cfservicebrokers
+  - cfserviceinstances
+  - cfserviceofferings
+  - cfserviceplans
+  - cfspaces
+  - cftasks
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - korifi.cloudfoundry.org
+  resources:
+  - appworkloads/finalizers
+  - builderinfos/finalizers
+  - buildworkloads/finalizers
+  - cfapps/finalizers
+  - cfbuilds/finalizers
+  - cfdomains/finalizers
+  - cforgs/finalizers
+  - cfprocesses/finalizers
+  - cfroutes/finalizers
+  - cfservicebindings/finalizers
+  - cfserviceinstances/finalizers
+  - cfspaces/finalizers
+  - cftasks/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - korifi.cloudfoundry.org
+  resources:
+  - appworkloads/status
+  - cfdomains/status
+  verbs:
+  - patch
+- apiGroups:
+  - korifi.cloudfoundry.org
+  resources:
+  - builderinfos/status
+  - cfapps/status
+  - cfbuilds/status
+  - cforgs/status
+  - cfpackages/finalizers
+  - cfpackages/status
+  - cfprocesses/status
+  - cfroutes/status
+  - cfservicebindings/status
+  - cfservicebrokers/status
+  - cfserviceinstances/status
+  - cfspaces/status
+  - cftasks/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - korifi.cloudfoundry.org
+  resources:
+  - buildworkloads/status
+  verbs:
+  - get
+- apiGroups:
+  - korifi.cloudfoundry.org
+  resources:
+  - cfapps
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - korifi.cloudfoundry.org
+  resources:
+  - cfdomains
+  - runnerinfos
+  - taskworkloads
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - korifi.cloudfoundry.org
+  resources:
+  - cfsecuritygroups
+  verbs:
+  - create
+- apiGroups:
+  - korifi.cloudfoundry.org
+  resources:
+  - runnerinfos/status
+  verbs:
+  - get
+  - patch
+- apiGroups:
+  - kpack.io
+  resources:
+  - clusterbuilders
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - kpack.io
+  resources:
+  - clusterbuilders/status
+  verbs:
+  - get
+- apiGroups:
+  - metrics.k8s.io
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - create
+  - deletecollection
+- apiGroups:
+  - policy
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - watch

--- a/dependencies/korifi/controllers/service.yaml
+++ b/dependencies/korifi/controllers/service.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: korifi-controllers-webhook-service
+  namespace: {{ .Release.Namespace }}
+spec:
+  ports:
+  - port: 443
+    targetPort: 9443
+  selector:
+    app: korifi-controllers
+
+{{- if .Values.debug }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: controller-manager-debug-port
+  namespace: {{ .Release.Namespace }}
+spec:
+  ports:
+    - name: debug-30051
+      nodePort: 30051
+      port: 30051
+      protocol: TCP
+      targetPort: 40000
+  selector:
+    app: korifi-controllers
+  type: NodePort
+{{- end }}

--- a/dependencies/korifi/controllers/webhook-cert.yaml
+++ b/dependencies/korifi/controllers/webhook-cert.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.generateInternalCertificates }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ .Values.controllers.webhookCertSecret }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  dnsNames:
+  - korifi-controllers-webhook-service.{{ .Release.Namespace }}.svc
+  - korifi-controllers-webhook-service.{{ .Release.Namespace }}.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: selfsigned-issuer
+  secretName: {{ .Values.controllers.webhookCertSecret }}
+{{- end}}

--- a/dependencies/korifi/job-task-runner/deployment.yaml
+++ b/dependencies/korifi/job-task-runner/deployment.yaml
@@ -1,0 +1,70 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: korifi-job-task-runner
+  name: korifi-job-task-runner-controller-manager
+  namespace: {{ .Release.Namespace }}
+spec:
+  replicas: {{ .Values.jobTaskRunner.replicas }}
+  selector:
+    matchLabels:
+      app: korifi-job-task-runner
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8080"
+        prometheus.io/scrape: "true"
+      labels:
+        app: korifi-job-task-runner
+    spec:
+      containers:
+      - name: manager
+        image: {{ .Values.jobTaskRunner.image }}
+{{- if .Values.debug }}
+        command:
+        - "/dlv"
+        args:
+        - "--listen=:40000"
+        - "--headless=true"
+        - "--api-version=2"
+        - "exec"
+        - "/manager"
+        - "--continue"
+        - "--accept-multiclient"
+        - "--"
+        - "--health-probe-bind-address=:8081"
+        - "--leader-elect"
+        - "--ttl={{ required "jobTTL is required" .Values.jobTaskRunner.jobTTL }}"
+{{- else }}
+        args:
+        - --health-probe-bind-address=:8081
+        - --leader-elect
+        - --ttl={{ required "jobTTL is required" .Values.jobTaskRunner.jobTTL }}
+{{- end }}
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        ports:
+        - containerPort: 8080
+          name: metrics
+          protocol: TCP
+        resources:
+        {{- .Values.jobTaskRunner.resources | toYaml | nindent 10 }}
+        {{- include "korifi.securityContext" . | indent 8 }}
+      {{- include "korifi.podSecurityContext" . | indent 6 }}
+      serviceAccountName: korifi-job-task-runner-controller-manager
+{{- if .Values.jobTaskRunner.nodeSelector }}
+      nodeSelector:
+      {{ toYaml .Values.jobTaskRunner.nodeSelector | indent 8 }}
+{{- end }}
+{{- if .Values.jobTaskRunner.tolerations }}
+      tolerations:
+      {{- toYaml .Values.jobTaskRunner.tolerations | nindent 8 }}
+{{- end }}
+      terminationGracePeriodSeconds: 10

--- a/dependencies/korifi/job-task-runner/rbac.yaml
+++ b/dependencies/korifi/job-task-runner/rbac.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: korifi-job-task-runner-controller-manager
+  namespace: {{ .Release.Namespace }}
+imagePullSecrets:
+{{- range .Values.systemImagePullSecrets }}
+- name: {{ . | quote }}
+{{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: korifi-job-task-runner-leader-election-rolebinding
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: korifi-controllers-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: korifi-job-task-runner-controller-manager
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: korifi-job-task-runner-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: korifi-job-task-runner-taskworkload-manager-role
+subjects:
+- kind: ServiceAccount
+  name: korifi-job-task-runner-controller-manager
+  namespace: {{ .Release.Namespace }}

--- a/dependencies/korifi/job-task-runner/role.yaml
+++ b/dependencies/korifi/job-task-runner/role.yaml
@@ -1,0 +1,45 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: korifi-job-task-runner-taskworkload-manager-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+- apiGroups:
+  - korifi.cloudfoundry.org
+  resources:
+  - taskworkloads
+  verbs:
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - korifi.cloudfoundry.org
+  resources:
+  - taskworkloads/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - korifi.cloudfoundry.org
+  resources:
+  - taskworkloads/status
+  verbs:
+  - get
+  - patch

--- a/dependencies/korifi/job-task-runner/runner-rbac.yaml
+++ b/dependencies/korifi/job-task-runner/runner-rbac.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    cloudfoundry.org/propagate-service-account: "true"
+    cloudfoundry.org/propagate-deletion: "false"
+  name: korifi-task
+  namespace: {{ .Values.rootNamespace }}

--- a/dependencies/korifi/job-task-runner/service.yaml
+++ b/dependencies/korifi/job-task-runner/service.yaml
@@ -1,0 +1,18 @@
+---
+{{- if .Values.debug }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: korifi-job-task-runner-debug-port
+  namespace: {{ .Release.Namespace }}
+spec:
+  ports:
+    - name: debug-30053
+      nodePort: 30053
+      port: 30053
+      protocol: TCP
+      targetPort: 40000
+  selector:
+    app: korifi-job-task-runner
+  type: NodePort
+{{- end }}

--- a/dependencies/korifi/kpack-image-builder/cluster-builder.yaml
+++ b/dependencies/korifi/kpack-image-builder/cluster-builder.yaml
@@ -1,0 +1,51 @@
+{{- if not .Values.kpackImageBuilder.clusterBuilderName }}
+apiVersion: kpack.io/v1alpha2
+kind: ClusterStore
+metadata:
+  name: cf-default-buildpacks
+spec:
+  sources:
+  - image: paketobuildpacks/java
+  - image: paketobuildpacks/nodejs
+  - image: paketobuildpacks/ruby
+  - image: paketobuildpacks/procfile
+  - image: paketobuildpacks/go
+---
+apiVersion: kpack.io/v1alpha2
+kind: ClusterStack
+metadata:
+  name: cf-default-stack
+spec:
+  id: "io.buildpacks.stacks.jammy"
+  buildImage:
+    image: paketobuildpacks/build-jammy-full
+  runImage:
+    image: paketobuildpacks/run-jammy-full
+---
+apiVersion: kpack.io/v1alpha2
+kind: ClusterBuilder
+metadata:
+  name: cf-kpack-cluster-builder
+spec:
+  serviceAccountRef:
+    name: kpack-service-account
+    namespace: {{ .Values.rootNamespace }}
+  tag: {{ required "builderRepository is required when clusterBuilderName is unset" .Values.kpackImageBuilder.builderRepository }}
+  stack:
+    name: cf-default-stack
+    kind: ClusterStack
+  store:
+    name: cf-default-buildpacks
+    kind: ClusterStore
+  order:
+  - group:
+    - id: paketo-buildpacks/java
+  - group:
+    - id: paketo-buildpacks/go
+  - group:
+    - id: paketo-buildpacks/nodejs
+  - group:
+    - id: paketo-buildpacks/ruby
+  - group:
+    - id: paketo-buildpacks/procfile
+{{- end }}

--- a/dependencies/korifi/kpack-image-builder/configmap.yaml
+++ b/dependencies/korifi/kpack-image-builder/configmap.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: korifi-kpack-image-builder-config
+  namespace: {{ .Release.Namespace }}
+data:
+  config.yaml: |-
+    cfRootNamespace: {{ .Values.rootNamespace }}
+    clusterBuilderName: {{ .Values.kpackImageBuilder.clusterBuilderName | default "cf-kpack-cluster-builder" }}
+    builderReadinessTimeout: {{ required "builderReadinessTimeout is required" .Values.kpackImageBuilder.builderReadinessTimeout }}
+    containerRepositoryPrefix: {{ .Values.containerRepositoryPrefix | quote }}
+    builderServiceAccount: kpack-service-account
+    cfStagingResources:
+      buildCacheMB: {{ .Values.stagingRequirements.buildCacheMB }}
+      diskMB: {{ .Values.stagingRequirements.diskMB }}
+      memoryMB: {{ .Values.stagingRequirements.memoryMB }}
+    {{- if .Values.eksContainerRegistryRoleARN }}
+    containerRegistryType: "ECR"
+    {{- end }}

--- a/dependencies/korifi/kpack-image-builder/deployment.yaml
+++ b/dependencies/korifi/kpack-image-builder/deployment.yaml
@@ -1,0 +1,95 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: korifi-kpack-image-builder
+  name: korifi-kpack-image-builder-controller-manager
+  namespace: {{ .Release.Namespace }}
+spec:
+  replicas: {{ .Values.kpackImageBuilder.replicas | default 1}}
+  selector:
+    matchLabels:
+      app: korifi-kpack-image-builder
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8080"
+        prometheus.io/scrape: "true"
+        checksum/config: {{ tpl ($.Files.Get "controllers/configmap.yaml") $ | sha256sum }}
+      labels:
+        app: korifi-kpack-image-builder
+    spec:
+      containers:
+      - name: manager
+        image: {{ .Values.kpackImageBuilder.image }}
+{{- if .Values.debug }}
+        command:
+        - "/dlv"
+        args:
+        - "--listen=:40000"
+        - "--headless=true"
+        - "--api-version=2"
+        - "exec"
+        - "/manager"
+        - "--continue"
+        - "--accept-multiclient"
+        - "--"
+        - "--health-probe-bind-address=:8081"
+        - "--leader-elect"
+        - "--config=/etc/korifi-kpack-image-builder-config"
+{{- else }}
+        args:
+        - --health-probe-bind-address=:8081
+        - --leader-elect
+        - --config=/etc/korifi-kpack-image-builder-config
+{{- end }}
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        - containerPort: 8080
+          name: metrics
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+        {{- .Values.jobTaskRunner.resources | toYaml | nindent 10 }}
+        {{- include "korifi.securityContext" . | indent 8 }}
+        volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: cert
+          readOnly: true
+        - mountPath: /etc/korifi-kpack-image-builder-config
+          name: korifi-kpack-image-builder-config
+          readOnly: true
+      {{- include "korifi.podSecurityContext" . | indent 6 }}
+      serviceAccountName: korifi-kpack-image-builder-controller-manager
+{{- if .Values.kpackImageBuilder.nodeSelector }}
+      nodeSelector:
+      {{ toYaml .Values.kpackImageBuilder.nodeSelector | indent 8 }}
+{{- end }}
+{{- if .Values.kpackImageBuilder.tolerations }}
+      tolerations:
+      {{- toYaml .Values.kpackImageBuilder.tolerations | nindent 8 }}
+{{- end }}
+      terminationGracePeriodSeconds: 10
+      volumes:
+      - name: cert
+        secret:
+          defaultMode: 420
+          secretName: {{ .Values.kpackImageBuilder.webhookCertSecret }}
+      - configMap:
+          name: korifi-kpack-image-builder-config
+        name: korifi-kpack-image-builder-config

--- a/dependencies/korifi/kpack-image-builder/manifests.yaml
+++ b/dependencies/korifi/kpack-image-builder/manifests.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: korifi-kpack-image-builder-mutating-webhook-configuration
+  annotations:
+    cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/{{ .Values.kpackImageBuilder.webhookCertSecret }}'
+webhooks:
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: korifi-kpack-image-builder-webhook-service
+        namespace: '{{ .Release.Namespace }}'
+        path: /mutate-korifi-cloudfoundry-org-v1alpha1-kpack-image-builder-finalizer
+      caBundle: '{{ include "korifi.webhookCaBundle" (set . "component" "kpackImageBuilder") }}'
+    failurePolicy: Fail
+    name: mcf-kib-finalizer.korifi.cloudfoundry.org
+    rules:
+      - apiGroups:
+          - korifi.cloudfoundry.org
+          - kpack.io
+        apiVersions:
+          - v1alpha1
+          - v1alpha2
+        operations:
+          - CREATE
+        resources:
+          - buildworkloads
+          - builds
+    sideEffects: None

--- a/dependencies/korifi/kpack-image-builder/post-install-builderinfo.yaml
+++ b/dependencies/korifi/kpack-image-builder/post-install-builderinfo.yaml
@@ -1,0 +1,50 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  annotations:
+    # This is what defines this resource as a hook. Without this line, the
+    # job is considered part of the release.
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+  name: create-builderinfo
+  namespace: {{ .Release.Namespace }}
+spec:
+  template:
+    metadata:
+      name: create-builderinfo
+      labels:
+        app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+        app.kubernetes.io/instance: {{ .Release.Name | quote }}
+        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    spec:
+      serviceAccountName: korifi-controllers-controller-manager
+      restartPolicy: Never
+      {{- include "korifi.podSecurityContext" . | indent 6 }}
+      containers:
+      - name: post-install-create-builderinfo
+        image: {{ .Values.helm.hooksImage }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          runAsUser: 1000
+          capabilities:
+            drop:
+            - ALL
+          seccompProfile:
+            type: RuntimeDefault
+        command:
+        - sh
+        - -c
+        - |
+          cat <<EOF | kubectl -n {{ .Values.rootNamespace }} apply -f -
+          apiVersion: korifi.cloudfoundry.org/v1alpha1
+          kind: BuilderInfo
+          metadata:
+            name: kpack-image-builder
+          EOF

--- a/dependencies/korifi/kpack-image-builder/pre-delete-builderinfo.yaml
+++ b/dependencies/korifi/kpack-image-builder/pre-delete-builderinfo.yaml
@@ -1,0 +1,99 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+  name: delete-builderinfo
+  namespace: {{ .Release.Namespace }}
+spec:
+  template:
+    metadata:
+      name: delete-builderinfo
+      labels:
+        app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+        app.kubernetes.io/instance: {{ .Release.Name | quote }}
+        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    spec:
+      serviceAccountName: delete-builderinfo-service-account
+      restartPolicy: Never
+      {{- include "korifi.podSecurityContext" . | indent 6 }}
+      containers:
+      - name: pre-delete-builderinfo
+        image: {{ .Values.helm.hooksImage }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          runAsUser: 1000
+          capabilities:
+            drop:
+            - ALL
+          seccompProfile:
+            type: RuntimeDefault
+        command:
+        - sh
+        - -c
+        - |
+          if kubectl get crd builderinfos.korifi.cloudfoundry.org; then
+            kubectl -n {{ .Values.rootNamespace }} delete builderinfo kpack-image-builder --ignore-not-found
+          fi
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: delete-builderinfo-service-account
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    helm.sh/hook: pre-delete
+    helm.sh/hook-delete-policy: before-hook-creation
+    helm.sh/hook-weight: "-10"
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: delete-builderinfo-role
+  annotations:
+    helm.sh/hook: pre-delete
+    helm.sh/hook-delete-policy: before-hook-creation
+    helm.sh/hook-weight: "-10"
+rules:
+- apiGroups:
+  - "apiextensions.k8s.io"
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+- apiGroups:
+  - "korifi.cloudfoundry.org"
+  resources:
+  - builderinfos
+  verbs:
+  - get
+  - list
+  - delete
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: delete-builderinfo-role-binding
+  annotations:
+    helm.sh/hook: pre-delete
+    helm.sh/hook-delete-policy: before-hook-creation
+    helm.sh/hook-weight: "-5"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: delete-builderinfo-role
+subjects:
+- kind: ServiceAccount
+  name: delete-builderinfo-service-account
+  namespace: {{ .Release.Namespace }}

--- a/dependencies/korifi/kpack-image-builder/rbac.yaml
+++ b/dependencies/korifi/kpack-image-builder/rbac.yaml
@@ -1,0 +1,41 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: korifi-kpack-image-builder-controller-manager
+  namespace: {{ .Release.Namespace }}
+  {{- if .Values.eksContainerRegistryRoleARN }}
+  annotations:
+    eks.amazonaws.com/role-arn: {{ .Values.eksContainerRegistryRoleARN }}
+  {{- end }}
+imagePullSecrets:
+{{- range .Values.systemImagePullSecrets }}
+- name: {{ . | quote }}
+{{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: korifi-kpack-image-builder-leader-election-rolebinding
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: korifi-controllers-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: korifi-kpack-image-builder-controller-manager
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: korifi-kpack-image-builder-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: korifi-kpack-build-manager-role
+subjects:
+- kind: ServiceAccount
+  name: korifi-kpack-image-builder-controller-manager
+  namespace: {{ .Release.Namespace }}

--- a/dependencies/korifi/kpack-image-builder/role.yaml
+++ b/dependencies/korifi/kpack-image-builder/role.yaml
@@ -1,0 +1,105 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: korifi-kpack-build-manager-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  - serviceaccounts
+  verbs:
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets/status
+  - serviceaccounts/status
+  verbs:
+  - get
+- apiGroups:
+  - korifi.cloudfoundry.org
+  resources:
+  - builderinfos
+  - buildworkloads
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - korifi.cloudfoundry.org
+  resources:
+  - builderinfos/status
+  - buildworkloads/status
+  verbs:
+  - get
+  - patch
+- apiGroups:
+  - kpack.io
+  resources:
+  - builders
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - kpack.io
+  resources:
+  - builds
+  verbs:
+  - deletecollection
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - kpack.io
+  resources:
+  - builds/finalizers
+  - builds/status
+  - images/status
+  verbs:
+  - get
+  - patch
+- apiGroups:
+  - kpack.io
+  resources:
+  - clusterbuilders
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - kpack.io
+  resources:
+  - clusterbuilders/status
+  verbs:
+  - get
+- apiGroups:
+  - kpack.io
+  resources:
+  - images
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - list
+  - watch

--- a/dependencies/korifi/kpack-image-builder/service-account.yaml
+++ b/dependencies/korifi/kpack-image-builder/service-account.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kpack-service-account
+  namespace: {{ .Values.rootNamespace }}
+  annotations:
+    cloudfoundry.org/propagate-service-account: "true"
+    cloudfoundry.org/propagate-deletion: "false"
+    {{- if .Values.eksContainerRegistryRoleARN }}
+    eks.amazonaws.com/role-arn: {{ .Values.eksContainerRegistryRoleARN }}
+    {{- end }}
+{{- if not .Values.eksContainerRegistryRoleARN }}
+{{- if .Values.containerRegistrySecrets }}
+secrets:
+{{- range .Values.containerRegistrySecrets }}
+- name: {{ . | quote }}
+{{- end }}
+imagePullSecrets:
+{{- range .Values.containerRegistrySecrets }}
+- name: {{ . | quote }}
+{{- end }}
+{{- else }}
+secrets:
+- name: {{ .Values.containerRegistrySecret | quote }}
+imagePullSecrets:
+- name: {{ .Values.containerRegistrySecret | quote }}
+{{- end }}
+{{- end }}

--- a/dependencies/korifi/kpack-image-builder/service.yaml
+++ b/dependencies/korifi/kpack-image-builder/service.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: korifi-kpack-image-builder-webhook-service
+  namespace: {{ .Release.Namespace }}
+spec:
+  ports:
+  - port: 443
+    targetPort: 9443
+  selector:
+    app: korifi-kpack-image-builder
+---
+{{- if .Values.debug }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: korifi-kpack-image-builder-debug-port
+  namespace: {{ .Release.Namespace }}
+spec:
+  ports:
+    - name: debug-30054
+      nodePort: 30054
+      port: 30054
+      protocol: TCP
+      targetPort: 40000
+  selector:
+    app: korifi-kpack-image-builder
+  type: NodePort
+{{- end }}

--- a/dependencies/korifi/kpack-image-builder/webhook-cert.yaml
+++ b/dependencies/korifi/kpack-image-builder/webhook-cert.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.generateInternalCertificates }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ .Values.kpackImageBuilder.webhookCertSecret }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  dnsNames:
+  - korifi-kpack-image-builder-webhook-service.{{ .Release.Namespace }}.svc
+  - korifi-kpack-image-builder-webhook-service.{{ .Release.Namespace }}.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: selfsigned-issuer
+  secretName: {{ .Values.kpackImageBuilder.webhookCertSecret }}
+{{- end}}

--- a/dependencies/korifi/migration/post-upgrade-migration.yaml
+++ b/dependencies/korifi/migration/post-upgrade-migration.yaml
@@ -1,0 +1,43 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  annotations:
+    # This is what defines this resource as a hook. Without this line, the
+    # job is considered part of the release.
+    "helm.sh/hook": post-upgrade
+    "helm.sh/hook-weight": "-9999"
+    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+  name: post-upgrade-migration
+  namespace: {{ .Release.Namespace }}
+spec:
+  template:
+    metadata:
+      name: post-upgrade-migration
+      labels:
+        app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+        app.kubernetes.io/instance: {{ .Release.Name | quote }}
+        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    spec:
+      serviceAccountName: korifi-controllers-controller-manager
+      restartPolicy: Never
+      {{- include "korifi.podSecurityContext" . | indent 6 }}
+      containers:
+      - name: post-upgrade-migration
+        env:
+        - name: KORIFI_VERSION
+          value: "{{ .Chart.Version }}"
+        image: {{ .Values.migration.image }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          runAsUser: 1000
+          capabilities:
+            drop:
+            - ALL
+          seccompProfile:
+            type: RuntimeDefault

--- a/dependencies/korifi/statefulset-runner/deployment.yaml
+++ b/dependencies/korifi/statefulset-runner/deployment.yaml
@@ -1,0 +1,77 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: korifi-statefulset-runner
+  name: korifi-statefulset-runner-controller-manager
+  namespace: {{ .Release.Namespace }}
+spec:
+  replicas: {{ .Values.statefulsetRunner.replicas }}
+  selector:
+    matchLabels:
+      app: korifi-statefulset-runner
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8080"
+        prometheus.io/scrape: "true"
+      labels:
+        app: korifi-statefulset-runner
+    spec:
+      containers:
+      - name: manager
+        image: {{ .Values.statefulsetRunner.image }}
+{{- if .Values.debug }}
+        command:
+        - "/dlv"
+        args:
+        - "--listen=:40000"
+        - "--headless=true"
+        - "--api-version=2"
+        - "exec"
+        - "/manager"
+        - "--continue"
+        - "--accept-multiclient"
+        - "--"
+        - "--health-probe-bind-address=:8081"
+        - "--leader-elect"
+{{- else }}
+        args:
+        - --health-probe-bind-address=:8081
+        - --leader-elect
+{{- end }}
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        ports:
+        - containerPort: 8080
+          name: metrics
+          protocol: TCP
+        resources:
+        {{- .Values.statefulsetRunner.resources | toYaml | nindent 10 }}
+        {{- include "korifi.securityContext" . | indent 8 }}
+        volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: cert
+          readOnly: true
+      {{- include "korifi.podSecurityContext" . | indent 6 }}
+      serviceAccountName: korifi-statefulset-runner-controller-manager
+{{- if .Values.statefulsetRunner.nodeSelector }}
+      nodeSelector:
+      {{ toYaml .Values.statefulsetRunner.nodeSelector | indent 8 }}
+{{- end }}
+{{- if .Values.statefulsetRunner.tolerations }}
+      tolerations:
+      {{- toYaml .Values.statefulsetRunner.tolerations | nindent 8 }}
+{{- end }}
+      terminationGracePeriodSeconds: 10
+      volumes:
+      - name: cert
+        secret:
+          defaultMode: 420
+          secretName: {{ .Values.statefulsetRunner.webhookCertSecret }}

--- a/dependencies/korifi/statefulset-runner/manifests.yaml
+++ b/dependencies/korifi/statefulset-runner/manifests.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: korifi-statefulset-runner-mutating-webhook-configuration
+  annotations:
+    cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/{{ .Values.statefulsetRunner.webhookCertSecret }}'
+webhooks:
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: korifi-statefulset-runner-webhook-service
+        namespace: '{{ .Release.Namespace }}'
+        path: /mutate-korifi-cloudfoundry-org-v1alpha1-appworkload
+      caBundle: '{{ include "korifi.webhookCaBundle" (set . "component" "statefulsetRunner") }}'
+    failurePolicy: Fail
+    name: mappworkload.korifi.cloudfoundry.org
+    rules:
+      - apiGroups:
+          - korifi.cloudfoundry.org
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+        resources:
+          - appworkloads
+    sideEffects: None

--- a/dependencies/korifi/statefulset-runner/post-install-runnerinfo.yaml
+++ b/dependencies/korifi/statefulset-runner/post-install-runnerinfo.yaml
@@ -1,0 +1,52 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  annotations:
+    # This is what defines this resource as a hook. Without this line, the
+    # job is considered part of the release.
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+  name: create-runnerinfo
+  namespace: {{ .Release.Namespace }}
+spec:
+  template:
+    metadata:
+      name: create-runnerinfo
+      labels:
+        app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+        app.kubernetes.io/instance: {{ .Release.Name | quote }}
+        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    spec:
+      serviceAccountName: korifi-statefulset-runner-controller-manager
+      restartPolicy: Never
+      {{- include "korifi.podSecurityContext" . | indent 6 }}
+      containers:
+      - name: post-install-create-runnerinfo
+        image: {{ .Values.helm.hooksImage }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          runAsUser: 1000
+          capabilities:
+            drop:
+            - ALL
+          seccompProfile:
+            type: RuntimeDefault
+        command:
+        - sh
+        - -c
+        - |
+          cat <<EOF | kubectl -n {{ .Values.rootNamespace }} apply -f -
+          apiVersion: korifi.cloudfoundry.org/v1alpha1
+          kind: RunnerInfo
+          metadata:
+            name: statefulset-runner
+          spec:
+            runnerName: statefulset-runner
+          EOF

--- a/dependencies/korifi/statefulset-runner/rbac.yaml
+++ b/dependencies/korifi/statefulset-runner/rbac.yaml
@@ -1,0 +1,36 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: korifi-statefulset-runner-controller-manager
+  namespace: {{ .Release.Namespace }}
+imagePullSecrets:
+{{- range .Values.systemImagePullSecrets }}
+- name: {{ . | quote }}
+{{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: korifi-statefulset-runner-leader-election-rolebinding
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: korifi-controllers-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: korifi-statefulset-runner-controller-manager
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: korifi-statefulset-runner-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: korifi-statefulset-runner-appworkload-manager-role
+subjects:
+- kind: ServiceAccount
+  name: korifi-statefulset-runner-controller-manager
+  namespace: {{ .Release.Namespace }}

--- a/dependencies/korifi/statefulset-runner/role.yaml
+++ b/dependencies/korifi/statefulset-runner/role.yaml
@@ -1,0 +1,59 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: korifi-statefulset-runner-appworkload-manager-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - create
+  - deletecollection
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - korifi.cloudfoundry.org
+  resources:
+  - appworkloads
+  - runnerinfos
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - korifi.cloudfoundry.org
+  resources:
+  - appworkloads/status
+  - runnerinfos/status
+  verbs:
+  - get
+  - patch
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - create
+  - deletecollection
+  - patch

--- a/dependencies/korifi/statefulset-runner/runner-rbac.yaml
+++ b/dependencies/korifi/statefulset-runner/runner-rbac.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    cloudfoundry.org/propagate-service-account: "true"
+    cloudfoundry.org/propagate-deletion: "false"
+  name: korifi-app
+  namespace: {{ .Values.rootNamespace }}

--- a/dependencies/korifi/statefulset-runner/service.yaml
+++ b/dependencies/korifi/statefulset-runner/service.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: korifi-statefulset-runner-webhook-service
+  namespace: {{ .Release.Namespace }}
+spec:
+  ports:
+  - port: 443
+    targetPort: 9443
+  selector:
+    app: korifi-statefulset-runner
+---
+{{- if .Values.debug }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: korifi-statefulset-runner-debug-port
+  namespace: {{ .Release.Namespace }}
+spec:
+  ports:
+    - name: debug-30055
+      nodePort: 30055
+      port: 30055
+      protocol: TCP
+      targetPort: 40000
+  selector:
+    app: korifi-statefulset-runner
+  type: NodePort
+{{- end }}

--- a/dependencies/korifi/statefulset-runner/webhook-cert.yaml
+++ b/dependencies/korifi/statefulset-runner/webhook-cert.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.generateInternalCertificates }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ .Values.statefulsetRunner.webhookCertSecret }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  dnsNames:
+  - korifi-statefulset-runner-webhook-service.{{ .Release.Namespace }}.svc
+  - korifi-statefulset-runner-webhook-service.{{ .Release.Namespace }}.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: selfsigned-issuer
+  secretName: {{ .Values.statefulsetRunner.webhookCertSecret }}
+{{- end}}

--- a/dependencies/korifi/templates/_helpers.yaml
+++ b/dependencies/korifi/templates/_helpers.yaml
@@ -1,0 +1,55 @@
+{{- define "korifi.resources" }}
+{{- if .Values.resources }}
+resources:
+  {{- if .Values.resources.requests }}
+  requests:
+    {{- if .Values.resources.requests.cpu }}
+    cpu: {{ .Values.resources.requests.cpu }}
+    {{- end }}
+    {{- if .Values.resources.requests.memory }}
+    memory: {{ .Values.resources.requests.memory }}
+    {{- end }}
+  {{- end }}
+  {{- if .Values.resources.limits }}
+  limits:
+    {{- if .Values.resources.limits.cpu }}
+    cpu: {{ .Values.resources.limits.cpu }}
+    {{- end }}
+    {{- if .Values.resources.limits.memory }}
+    memory: {{ .Values.resources.limits.memory }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+{{- end }}
+
+{{- define "korifi.securityContext" }}
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+    - ALL
+{{- if .Values.debug }}
+    add:
+    - SYS_PTRACE
+{{- end }}
+  runAsNonRoot: {{ not .Values.debug }}
+  seccompProfile:
+    type: RuntimeDefault
+{{- end }}
+
+{{- define "korifi.podSecurityContext" }}
+securityContext:
+  runAsNonRoot: {{ not .Values.debug }}
+  seccompProfile:
+    type: RuntimeDefault
+{{- end }}
+
+{{- define "korifi.webhookCaBundle" -}}
+{{- $caBundle := "" -}}
+{{- if not .Values.generateInternalCertificates -}}
+{{- $compValues := index .Values .component -}}
+{{- $webhookCertSecret := $compValues.webhookCertSecret -}}
+{{- $caBundle = index (lookup "v1" "Secret" .Release.Namespace $webhookCertSecret).data "ca.crt" -}}
+{{- end -}}
+{{ $caBundle }}
+{{- end -}}

--- a/dependencies/korifi/templates/admin-user.yaml
+++ b/dependencies/korifi/templates/admin-user.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: default-admin-binding
+  namespace: {{ .Values.rootNamespace }}
+  annotations:
+    cloudfoundry.org/propagate-cf-role: "true"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: korifi-controllers-admin
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: User
+    name: {{ .Values.adminUserName }}

--- a/dependencies/korifi/templates/cert-mgr-issuer.yaml
+++ b/dependencies/korifi/templates/cert-mgr-issuer.yaml
@@ -1,0 +1,9 @@
+{{- if or (eq .Values.generateIngressCertificates true) (eq .Values.generateInternalCertificates true) }}
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: selfsigned-issuer
+  namespace: {{ .Release.Namespace }}
+spec:
+  selfSigned: {}
+{{- end}}

--- a/dependencies/korifi/templates/components.yaml
+++ b/dependencies/korifi/templates/components.yaml
@@ -1,0 +1,53 @@
+{{- $ctx := . }}
+{{- if .Values.api.include }}
+{{- range $path, $_ := .Files.Glob "api/*.yaml" }}
+---
+{{ tpl ($.Files.Get $path) $ctx }}
+{{- end }}
+{{- end }}
+
+{{- if .Values.crds.include }}
+{{- range $path, $_ := .Files.Glob "controllers/crds/*.yaml" }}
+---
+{{ tpl ($.Files.Get $path) $ctx }}
+{{- end }}
+{{- end }}
+
+{{- range $path, $_ := .Files.Glob "controllers/cf_roles/*.yaml" }}
+---
+{{ tpl ($.Files.Get $path) $ctx }}
+{{- end }}
+
+{{- range $path, $_ := .Files.Glob "controllers/*.yaml" }}
+---
+{{ tpl ($.Files.Get $path) $ctx }}
+{{- end }}
+
+{{- if .Values.kpackImageBuilder.include }}
+{{- range $path, $_ := .Files.Glob "kpack-image-builder/*.yaml" }}
+---
+{{ tpl ($.Files.Get $path) $ctx }}
+{{- end }}
+{{- end }}
+
+{{- if .Values.jobTaskRunner.include }}
+{{- range $path, $_ := .Files.Glob "job-task-runner/*.yaml" }}
+---
+{{ tpl ($.Files.Get $path) $ctx }}
+{{- end }}
+{{- end }}
+
+{{- if .Values.statefulsetRunner.include }}
+{{- range $path, $_ := .Files.Glob "statefulset-runner/*.yaml" }}
+---
+{{ tpl ($.Files.Get $path) $ctx }}
+{{- end }}
+{{- end }}
+
+{{- if .Values.migration.include }}
+{{- range $path, $_ := .Files.Glob "migration/*.yaml" }}
+---
+{{ tpl ($.Files.Get $path) $ctx }}
+{{- end }}
+{{- end }}
+

--- a/dependencies/korifi/templates/gateway.yaml
+++ b/dependencies/korifi/templates/gateway.yaml
@@ -1,0 +1,61 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Release.Namespace }}-gateway
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: {{ .Values.controllers.workloadsTLSSecret }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  from:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    namespace: {{ .Release.Namespace }}-gateway
+  to:
+  - group: ""
+    kind: Secret
+    name: {{ .Values.controllers.workloadsTLSSecret }}
+---
+kind: Gateway
+apiVersion: gateway.networking.k8s.io/v1beta1
+metadata:
+  name: korifi
+  namespace: {{ .Release.Namespace }}-gateway
+spec:
+  gatewayClassName: {{ .Values.networking.gatewayClass }}
+  {{- if .Values.networking.gatewayInfrastructure }}
+  infrastructure:
+    {{- .Values.networking.gatewayInfrastructure | toYaml | nindent 4 }}
+  {{- end }}
+  listeners:
+  - allowedRoutes:
+      namespaces:
+        from: All
+    name: http-apps
+    port: {{ .Values.networking.gatewayPorts.http }}
+    protocol: HTTP
+  - allowedRoutes:
+      namespaces:
+        from: All
+    hostname: {{ .Values.api.apiServer.url }}
+    name: https-api
+    port: {{ .Values.networking.gatewayPorts.https }}
+    protocol: TLS
+    tls:
+      mode: Passthrough
+  - allowedRoutes:
+      namespaces:
+        from: All
+    hostname: "*.{{ .Values.defaultAppDomainName }}"
+    name: https-apps
+    port: {{ .Values.networking.gatewayPorts.https }}
+    protocol: HTTPS
+    tls:
+      certificateRefs:
+      - group: ""
+        kind: Secret
+        name: {{ .Values.controllers.workloadsTLSSecret }}
+        namespace: {{ .Release.Namespace }}
+      mode: Terminate

--- a/dependencies/korifi/values.schema.json
+++ b/dependencies/korifi/values.schema.json
@@ -1,0 +1,744 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "properties": {
+    "adminUserName": {
+      "description": "Name of the admin user that will be bound to the Cloud Foundry Admin role.",
+      "type": "string"
+    },
+    "rootNamespace": {
+      "description": "Root of the Cloud Foundry namespace hierarchy.",
+      "type": "string"
+    },
+    "debug": {
+      "description": "Enables remote debugging with [Delve](https://github.com/go-delve/delve).",
+      "type": "boolean"
+    },
+    "logLevel": {
+      "description": "Sets level of logging for api and controllers components. Can be 'info' or 'debug'.",
+      "type": "string",
+      "enum": ["info", "debug"]
+    },
+    "defaultAppDomainName": {
+      "description": "Base domain name for application URLs.",
+      "type": "string"
+    },
+    "generateIngressCertificates": {
+      "description": "Use `cert-manager` to generate self-signed certificates for the API and app endpoints.",
+      "type": "boolean"
+    },
+    "generateInternalCertificates": {
+      "description": "Use `cert-manager` to generate internal self-signed certificates, e.g. for the webhooks.",
+      "type": "boolean"
+    },
+    "containerRepositoryPrefix": {
+      "description": "The prefix of the container repository where package and droplet images will be pushed. This is suffixed with the app GUID and `-packages` or `-droplets`. For example, a value of `index.docker.io/korifi/` will result in `index.docker.io/korifi/<appGUID>-packages` and `index.docker.io/korifi/<appGUID>-droplets` being pushed.",
+      "type": "string",
+      "pattern": "^[a-z0-9]+([._-][a-z0-9]+)*(:[0-9]+)?(/[a-z0-9]+([._-][a-z0-9]+)*)*/?$"
+    },
+    "containerRegistrySecret": {
+      "deprecated": true,
+      "description": "Deprecated in favor of containerRegistrySecrets.",
+      "type": "string"
+    },
+    "containerRegistrySecrets": {
+      "description": "List of `Secret` names to use when pushing or pulling from package, droplet and kpack builder repositories. Required if eksContainerRegistryRoleARN not set. Ignored if eksContainerRegistryRoleARN is set.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "systemImagePullSecrets": {
+      "description": "List of `Secret` names to be used when pulling Korifi system images from private registries",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "eksContainerRegistryRoleARN": {
+      "description": "Amazon Resource Name (ARN) of the IAM role to use to access the ECR registry from an EKS deployed Korifi. Required if containerRegistrySecret not set.",
+      "type": "string"
+    },
+    "reconcilers": {
+      "type": "object",
+      "properties": {
+        "build": {
+          "description": "ID of the image builder to set on all `BuildWorkload` objects. Defaults to `kpack-image-builder`.",
+          "type": "string"
+        },
+        "app": {
+          "description": "ID of the workload runner to set on all `AppWorkload` objects. Defaults to `statefulset-runner`.",
+          "type": "string"
+        }
+      },
+      "required": ["build", "run"]
+    },
+    "stagingRequirements": {
+      "type": "object",
+      "properties": {
+        "memoryMB": {
+          "description": "Memory request in MB for staging.",
+          "type": "integer"
+        },
+        "diskMB": {
+          "description": "Ephemeral Disk request in MB for staging apps.",
+          "type": "integer"
+        },
+        "buildCacheMB": {
+          "description": "Persistent disk in MB for caching staging artifacts across builds.",
+          "type": "integer"
+        }
+      },
+      "required": ["memoryMB", "diskMB", "buildCacheMB"]
+    },
+    "crds": {
+      "type": "object",
+      "required": ["include"],
+      "properties": {
+        "include": {
+          "description": "Install CRDs as part of the Helm installation.",
+          "type": "boolean"
+        }
+      }
+    },
+    "api": {
+      "properties": {
+        "include": {
+          "description": "Deploy the API component.",
+          "type": "boolean"
+        },
+        "nodeSelector": {
+          "description": "Node labels for korifi-api pod assignment.",
+          "type": "object",
+          "properties": {}
+        },
+        "tolerations": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "key": { "type": "string" },
+              "operator": { "type": "string" },
+              "value": { "type": "string" },
+              "effect": { "type": "string" }
+            },
+            "required": ["key", "operator", "effect"]
+          },
+          "description": "Korifi-api pod tolerations for taints."
+        },
+        "replicas": {
+          "description": "Number of replicas.",
+          "type": "integer"
+        },
+        "resources": {
+          "description": "[`ResourceRequirements`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#resourcerequirements-v1-core) for the API.",
+          "type": "object",
+          "properties": {
+            "requests": {
+              "description": "Resource requests.",
+              "type": "object",
+              "properties": {
+                "cpu": {
+                  "description": "CPU request.",
+                  "type": "string"
+                },
+                "memory": {
+                  "description": "Memory request.",
+                  "type": "string"
+                }
+              }
+            },
+            "limits": {
+              "description": "Resource limits.",
+              "type": "object",
+              "properties": {
+                "cpu": {
+                  "description": "CPU limit.",
+                  "type": "string"
+                },
+                "memory": {
+                  "description": "Memory limit.",
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "apiServer": {
+          "type": "object",
+          "properties": {
+            "url": {
+              "description": "API URL.",
+              "type": "string"
+            },
+            "port": {
+              "description": "API external port. Defaults to `443`.",
+              "type": "integer"
+            },
+            "internalPort": {
+              "description": "Port used internally by the API container.",
+              "type": "integer"
+            },
+            "ingressCertSecret": {
+              "description": "The name of the secret containing the TLS certificate for the API ingress.",
+              "type": "string"
+            },
+            "internalCertSecret": {
+              "description": "The name of the secret containing the TLS certificate for internal api access. It needs to be valid for 'korifi-api-svc.korifi.svc.cluster.local'.",
+              "type": "string"
+            },
+            "timeouts": {
+              "type": "object",
+              "description": "HTTP timeouts.",
+              "properties": {
+                "read": {
+                  "description": "Read timeout.",
+                  "type": "integer"
+                },
+                "write": {
+                  "description": "Write timeout.",
+                  "type": "integer"
+                },
+                "idle": {
+                  "description": "Idle timeout.",
+                  "type": "integer"
+                },
+                "readHeader": {
+                  "description": "Read header timeout.",
+                  "type": "integer"
+                }
+              },
+              "required": ["read", "write", "idle", "readHeader"]
+            }
+          },
+          "required": ["url", "port", "internalPort", "ingressCertSecret", "internalCertSecret", "timeouts"]
+        },
+        "image": {
+          "description": "Reference to the API container image.",
+          "type": "string"
+        },
+        "infoConfig": {
+          "type": "object",
+          "description": "The /v3/info endpoint configuration.",
+          "properties": {
+            "description": {
+              "description": "`description` attribute in the /v3/info endpoint",
+              "type": "string"
+            },
+            "name": {
+              "description": "`name` attribute in the /v3/info endpoint",
+              "type": "string"
+            },
+            "minCLIVersion": {
+              "description": "`minimum` CLI version attribute in the /v3/info endpoint",
+              "type": "string"
+            },
+            "recommendedCLIVersion": {
+              "description": "`recommended` CLI version attribute in the /v3/info endpoint",
+              "type": "string"
+            },
+            "custom": {
+              "description": "`custom` attribute in the /v3/info endpoint",
+              "type": "object",
+              "properties": {}
+            },
+            "supportAddress": {
+              "description": "`support` attribute in the /v3/info endpoint",
+              "type": "string"
+            }
+          },
+          "required": [
+            "description",
+            "name",
+            "minCLIVersion",
+            "recommendedCLIVersion",
+            "custom",
+            "supportAddress"
+          ]
+        },
+        "lifecycle": {
+          "type": "object",
+          "description": "Default lifecycle for apps.",
+          "properties": {
+            "type": {
+              "description": "Lifecycle type (only `buildpack` accepted currently).",
+              "type": "string",
+              "enum": ["buildpack"]
+            },
+            "stack": {
+              "description": "Stack.",
+              "type": "string"
+            }
+          },
+          "required": ["type", "stack"]
+        },
+        "userCertificateExpirationWarningDuration": {
+          "description": "Issue a warning if the user certificate provided for login has a long expiry. See [`time.ParseDuration`](https://pkg.go.dev/time#ParseDuration) for details on the format.",
+          "type": "string"
+        },
+        "authProxy": {
+          "type": "object",
+          "description": "Needed if using a cluster authentication proxy, e.g. [Pinniped](https://pinniped.dev/).",
+          "properties": {
+            "host": {
+              "description": "Must be a host string, a host:port pair, or a URL to the base of the apiserver.",
+              "type": "string"
+            },
+            "caCert": {
+              "description": "Proxy's PEM-encoded CA certificate (*not* as Base64).",
+              "type": "string"
+            }
+          }
+        },
+        "list": {
+          "type": "object",
+          "description": "List behaviour configuration",
+          "properties": {
+            "defaultPageSize": {
+              "description": "Page size in case 'per_page' query parameter is not provided in list queries",
+              "type": "integer"
+            }
+          }
+        }
+      },
+      "required": [
+        "include",
+        "apiServer",
+        "image",
+        "lifecycle",
+        "userCertificateExpirationWarningDuration"
+      ],
+      "type": "object"
+    },
+    "controllers": {
+      "properties": {
+        "replicas": {
+          "description": "Number of replicas.",
+          "type": "integer"
+        },
+        "nodeSelector": {
+          "description": "Node labels for korifi-controllers pod assignment.",
+          "type": "object",
+          "properties": {}
+        },
+        "tolerations": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "key": { "type": "string" },
+              "operator": { "type": "string" },
+              "value": { "type": "string" },
+              "effect": { "type": "string" }
+            },
+            "required": ["key", "operator", "effect"]
+          },
+          "description": "Korifi-controllers pod tolerations for taints."
+        },
+        "resources": {
+          "description": "[`ResourceRequirements`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#resourcerequirements-v1-core) for the API.",
+          "type": "object",
+          "properties": {
+            "requests": {
+              "description": "Resource requests.",
+              "type": "object",
+              "properties": {
+                "cpu": {
+                  "description": "CPU request.",
+                  "type": "string"
+                },
+                "memory": {
+                  "description": "Memory request.",
+                  "type": "string"
+                }
+              }
+            },
+            "limits": {
+              "description": "Resource limits.",
+              "type": "object",
+              "properties": {
+                "cpu": {
+                  "description": "CPU limit.",
+                  "type": "string"
+                },
+                "memory": {
+                  "description": "Memory limit.",
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "image": {
+          "description": "Reference to the controllers container image.",
+          "type": "string"
+        },
+        "webhookCertSecret": {
+          "description": "A secert containing the CA bundle and the certificate for the webhook server.",
+          "type": "string"
+        },
+        "processDefaults": {
+          "type": "object",
+          "properties": {
+            "memoryMB": {
+              "description": "Default memory limit for the `web` process.",
+              "type": "integer"
+            },
+            "diskQuotaMB": {
+              "description": "Default disk quota for the `web` process.",
+              "type": "integer"
+            }
+          },
+          "required": ["memoryMB", "diskQuotaMB"]
+        },
+        "taskTTL": {
+          "description": "How long before the `CFTask` object is deleted after the task has completed. See [`time.ParseDuration`](https://pkg.go.dev/time#ParseDuration) for details on the format, an additional `d` suffix for days is supported.",
+          "type": "string"
+        },
+        "workloadsTLSSecret": {
+          "description": "TLS secret used when setting up an app routes.",
+          "type": "string"
+        },
+        "namespaceLabels": {
+          "description": "Key-value pairs that are going to be set as labels on the namespaces created by Korifi.",
+          "type": "object",
+          "properties": {}
+        },
+        "extraVCAPApplicationValues": {
+          "description": "Key-value pairs that are going to be set in the VCAP_APPLICATION env var on apps. Nested values are not supported.",
+          "type": "object",
+          "properties": {}
+        },
+        "maxRetainedPackagesPerApp": {
+          "description": "How many 'ready' packages to keep, excluding the package associated with the app's current droplet. Older 'ready' packages will be deleted, along with their corresponding container images.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "maxRetainedBuildsPerApp": {
+          "description": "How many staged builds to keep, excluding the app's current droplet. Older staged builds will be deleted, along with their corresponding container images.",
+          "type": "integer",
+          "minimum": 1
+        }
+      },
+      "required": ["image", "taskTTL", "workloadsTLSSecret", "webhookCertSecret"],
+      "type": "object"
+    },
+    "kpackImageBuilder": {
+      "properties": {
+        "include": {
+          "description": "Deploy the `kpack-image-builder` component.",
+          "type": "boolean"
+        },
+        "replicas": {
+          "description": "Number of replicas.",
+          "type": "integer"
+        },
+        "resources": {
+          "description": "[`ResourceRequirements`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#resourcerequirements-v1-core) for the API.",
+          "type": "object",
+          "properties": {
+            "requests": {
+              "description": "Resource requests.",
+              "type": "object",
+              "properties": {
+                "cpu": {
+                  "description": "CPU request.",
+                  "type": "string"
+                },
+                "memory": {
+                  "description": "Memory request.",
+                  "type": "string"
+                }
+              }
+            },
+            "limits": {
+              "description": "Resource limits.",
+              "type": "object",
+              "properties": {
+                "cpu": {
+                  "description": "CPU limit.",
+                  "type": "string"
+                },
+                "memory": {
+                  "description": "Memory limit.",
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "clusterBuilderName": {
+          "description": "The name of the `ClusterBuilder` Kpack has been configured with. Leave blank to let `kpack-image-builder` create an example `ClusterBuilder`.",
+          "type": "string"
+        },
+        "builderReadinessTimeout": {
+          "description": "The time that the kpack Builder will be waited for if not in ready state, berfore the build workload fails. See [`time.ParseDuration`](https://pkg.go.dev/time#ParseDuration) for details on the format, an additional `d` suffix for days is supported.",
+          "type": "string"
+        },
+        "builderRepository": {
+          "description": "Container image repository to store the `ClusterBuilder` image. Required when `clusterBuilderName` is not provided.",
+          "type": "string",
+          "pattern": "^([a-z0-9]+([._-][a-z0-9]+)*(:[0-9]+)?(/[a-z0-9]+([._-][a-z0-9]+)*)*)?$"
+        },
+        "webhookCertSecret": {
+          "description": "A secert containing the CA bundle and the certificate for the webhook server.",
+          "type": "string"
+        }
+      },
+      "required": ["include", "builderReadinessTimeout", "webhookCertSecret"],
+      "type": "object"
+    },
+    "statefulsetRunner": {
+      "properties": {
+        "include": {
+          "description": "Deploy the `statefulset-runner` component.",
+          "type": "boolean"
+        },
+        "replicas": {
+          "description": "Number of replicas.",
+          "type": "integer"
+        },
+        "webhookCertSecret": {
+          "description": "A secert containing the CA bundle and the certificate for the webhook server.",
+          "type": "string"
+        },
+        "resources": {
+          "description": "[`ResourceRequirements`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#resourcerequirements-v1-core) for the API.",
+          "type": "object",
+          "properties": {
+            "requests": {
+              "description": "Resource requests.",
+              "type": "object",
+              "properties": {
+                "cpu": {
+                  "description": "CPU request.",
+                  "type": "string"
+                },
+                "memory": {
+                  "description": "Memory request.",
+                  "type": "string"
+                }
+              }
+            },
+            "limits": {
+              "description": "Resource limits.",
+              "type": "object",
+              "properties": {
+                "cpu": {
+                  "description": "CPU limit.",
+                  "type": "string"
+                },
+                "memory": {
+                  "description": "Memory limit.",
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "required": ["include", "webhookCertSecret"],
+      "type": "object"
+    },
+    "jobTaskRunner": {
+      "properties": {
+        "include": {
+          "description": "Deploy the `job-task-runner` component.",
+          "type": "boolean"
+        },
+        "replicas": {
+          "description": "Number of replicas.",
+          "type": "integer"
+        },
+        "resources": {
+          "description": "[`ResourceRequirements`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#resourcerequirements-v1-core) for the API.",
+          "type": "object",
+          "properties": {
+            "requests": {
+              "description": "Resource requests.",
+              "type": "object",
+              "properties": {
+                "cpu": {
+                  "description": "CPU request.",
+                  "type": "string"
+                },
+                "memory": {
+                  "description": "Memory request.",
+                  "type": "string"
+                }
+              }
+            },
+            "limits": {
+              "description": "Resource limits.",
+              "type": "object",
+              "properties": {
+                "cpu": {
+                  "description": "CPU limit.",
+                  "type": "string"
+                },
+                "memory": {
+                  "description": "Memory limit.",
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "jobTTL": {
+          "description": "How long before the `Job` backing up a task is deleted after completion. See [`time.ParseDuration`](https://pkg.go.dev/time#ParseDuration) for details on the format, an additional `d` suffix for days is supported.",
+          "type": "string"
+        }
+      },
+      "required": ["include", "jobTTL"],
+      "type": "object"
+    },
+    "networking": {
+      "type": "object",
+      "description": "Networking configuration",
+      "properties": {
+        "gatewayClass": {
+          "description": "The name of the GatewayClass Korifi Gateway references",
+          "type": "string"
+        },
+        "gatewayPorts": {
+          "description": "Ports for the Gateway listeners",
+          "type": "object",
+          "properties": {
+            "http": {
+              "description": "HTTP port",
+              "type": "integer",
+              "default": 80
+            },
+            "https": {
+              "description": "HTTPS port",
+              "type": "integer",
+              "default": 443
+            }
+          }
+        },
+        "gatewayInfrastructure": {
+          "description": "Optional GatewayInfrastructure property of the Gateway, see https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.GatewayInfrastructure for contents",
+          "type": ["object", "null"]
+        }
+      },
+      "required": ["gatewayClass"]
+    },
+    "helm": {
+      "properties": {
+        "hooksImage": {
+          "description": "Image for the helm hooks containing kubectl",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "migration": {
+      "properties": {
+        "include": {
+          "description": "Deploy the migration component.",
+          "type": "boolean"
+        }
+      },
+      "required": ["include"],
+      "type": "object"
+    },
+    "experimental": {
+      "properties": {
+        "routing": {
+          "properties": {
+            "disableRouteController": {
+              "description": "Disable route controller. Default value is 'false'.",
+              "type": "boolean"
+            }
+          },
+          "type": "object"
+        },
+        "managedServices": {
+          "properties": {
+            "enabled": {
+              "description": "Enable managed services support",
+              "type": "boolean"
+            },
+            "trustInsecureBrokers": {
+              "description": "Disable service broker certificate validation. Not recommended to be set to 'true' in production environments",
+              "type": "boolean"
+            }
+          },
+          "type": "object"
+        },
+        "securityGroups": {
+          "properties": {
+            "enabled": {
+              "description": "Enable security groups support",
+              "type": "boolean"
+            }
+          },
+          "type": "object"
+        },
+        "uaa": {
+          "properties": {
+            "enabled": {
+              "description": "Enable UAA support",
+              "type": "boolean"
+            },
+            "url": {
+              "description": "The url of a UAA instance",
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "externalLogCache": {
+          "properties": {
+            "enabled": {
+              "description": "Enable external LogCache",
+              "type": "boolean"
+            },
+            "url": {
+              "description": "The url of the exernal LogCache server",
+              "type": "string"
+            },
+            "trustInsecureLogCache": {
+              "description": "Disable external log cache certificate validation. Not recommended to be set to 'true' in production environments",
+              "type": "boolean"
+            }
+          },
+          "type": "object"
+        },
+        "api" : {
+          "k8sclient" : {
+            "properties": {
+              "qps" : {
+                "description": "The maximum QPS to the k8s API server, see https://github.com/kubernetes/client-go/blob/ec8a292223d913dc635704c6d57959e1bc00290a/rest/config.go#L117-L122",
+                "type": "number"
+              },
+              "burst" : {
+                "description": "The maximum burst for the QPS to the k8s API server, see https://github.com/kubernetes/client-go/blob/ec8a292223d913dc635704c6d57959e1bc00290a/rest/config.go#L124-L126",
+                "type": "integer"
+              }
+            },
+            "type": "object"
+          },
+          "type": "object"
+        }
+      },
+      "description": "Experimental features. No guarantees are provided and breaking/backwards incompatible changes should be expected. These features are not recommended for use in production environments.",
+      "type": "object"
+    }
+  },
+  "required": [
+    "adminUserName",
+    "containerRepositoryPrefix",
+    "defaultAppDomainName",
+    "logLevel",
+    "reconcilers",
+    "rootNamespace",
+    "stagingRequirements",
+    "api",
+    "controllers",
+    "kpackImageBuilder",
+    "statefulsetRunner",
+    "jobTaskRunner"
+  ],
+  "title": "Values",
+  "type": "object"
+}

--- a/dependencies/korifi/values.yaml
+++ b/dependencies/korifi/values.yaml
@@ -1,0 +1,228 @@
+---
+adminUserName: null
+api:
+  apiServer:
+    ingressCertSecret: korifi-api-ingress-cert
+    internalCertSecret: korifi-api-internal-cert
+    internalPort: 9000
+    port: 443
+    timeouts:
+      idle: 900
+      read: 900
+      readHeader: 10
+      write: 900
+    url: ""
+  authProxy:
+    caCert: ""
+    host: ""
+  image: index.docker.io/cloudfoundry/korifi-api@sha256:fc108285599acf8a52d6965c8add37f5a4936d28da2464d611e5f197cad7f321
+  include: true
+  infoConfig:
+    custom: {}
+    description: Korifi Cloud Foundry Environment
+    minCLIVersion: ""
+    name: korifi
+    recommendedCLIVersion: ""
+    supportAddress: https://www.cloudfoundry.org/technology/korifi/
+  lifecycle:
+    stack: cflinuxfs3
+    type: buildpack
+  list:
+    defaultPageSize: 50
+  nodeSelector: {}
+  replicas: 1
+  resources:
+    limits:
+      cpu: 1000m
+      memory: 1Gi
+    requests:
+      cpu: 50m
+      memory: 100Mi
+  tolerations: []
+  userCertificateExpirationWarningDuration: 168h
+containerRegistryCACertSecret: null
+containerRegistrySecrets:
+- image-registry-credentials
+controllers:
+  extraVCAPApplicationValues: {}
+  image: index.docker.io/cloudfoundry/korifi-controllers@sha256:ef36e1d33ccea4a5999af3ff415bd4c89e922cab29dff07c672a1a8b34e676f2
+  maxRetainedBuildsPerApp: 5
+  maxRetainedPackagesPerApp: 5
+  namespaceLabels: {}
+  nodeSelector: {}
+  processDefaults:
+    diskQuotaMB: 1024
+    memoryMB: 1024
+  replicas: 1
+  resources:
+    limits:
+      cpu: 1000m
+      memory: 1Gi
+    requests:
+      cpu: 50m
+      memory: 100Mi
+  taskTTL: 30d
+  tolerations: []
+  webhookCertSecret: korifi-controllers-webhook-cert
+  workloadsTLSSecret: korifi-workloads-ingress-cert
+crds:
+  include: true
+debug: false
+defaultAppDomainName: null
+eksContainerRegistryRoleARN: ""
+experimental:
+  api:
+    k8sclient:
+      burst: 0
+      qps: 0
+  externalLogCache:
+    enabled: false
+    trustInsecureLogCache: false
+    url: ""
+  managedServices:
+    enabled: false
+    trustInsecureBrokers: false
+  routing:
+    disableRouteController: false
+  securityGroups:
+    enabled: false
+  uaa:
+    enabled: false
+    url: ""
+generateIngressCertificates: false
+generateInternalCertificates: true
+helm:
+  hooksImage: alpine/k8s:1.25.2
+jobTaskRunner:
+  image: index.docker.io/cloudfoundry/korifi-job-task-runner@sha256:2ec5028a306e8a3eeaf412f016ba19efce53936c4998c22cec39059cc4a285a9
+  include: true
+  jobTTL: 24h
+  replicas: 1
+  resources:
+    limits:
+      cpu: 1000m
+      memory: 1Gi
+    requests:
+      cpu: 50m
+      memory: 100Mi
+kpackImageBuilder:
+  builderReadinessTimeout: 30s
+  builderRepository: ""
+  clusterBuilderName: ""
+  image: index.docker.io/cloudfoundry/korifi-kpack-image-builder@sha256:95d114b48fa709667ee648162745fc3c8a8f3b008c371c70e4e6aa73b55ac863
+  include: true
+  replicas: 1
+  resources:
+    limits:
+      cpu: 1000m
+      memory: 1Gi
+    requests:
+      cpu: 50m
+      memory: 100Mi
+  webhookCertSecret: korifi-kpack-image-builder-webhook-cert
+logLevel: info
+metadata:
+  annotations:
+    kbld.k14s.io/images: |
+      - origins:
+        - local:
+            path: /tmp/build/a625eeb5/korifi
+        - git:
+            dirty: true
+            remoteURL: https://github.com/cloudfoundry/korifi.git
+            sha: c16b9dcb043598b89f2ec81b3a1c31a4673ad98f
+        - tagged:
+            tags:
+            - latest
+            - 0.16.1
+        url: index.docker.io/cloudfoundry/korifi-api@sha256:fc108285599acf8a52d6965c8add37f5a4936d28da2464d611e5f197cad7f321
+      - origins:
+        - local:
+            path: /tmp/build/a625eeb5/korifi
+        - git:
+            dirty: true
+            remoteURL: https://github.com/cloudfoundry/korifi.git
+            sha: c16b9dcb043598b89f2ec81b3a1c31a4673ad98f
+        - tagged:
+            tags:
+            - latest
+            - 0.16.1
+        url: index.docker.io/cloudfoundry/korifi-controllers@sha256:ef36e1d33ccea4a5999af3ff415bd4c89e922cab29dff07c672a1a8b34e676f2
+      - origins:
+        - local:
+            path: /tmp/build/a625eeb5/korifi
+        - git:
+            dirty: true
+            remoteURL: https://github.com/cloudfoundry/korifi.git
+            sha: c16b9dcb043598b89f2ec81b3a1c31a4673ad98f
+        - tagged:
+            tags:
+            - latest
+            - 0.16.1
+        url: index.docker.io/cloudfoundry/korifi-job-task-runner@sha256:2ec5028a306e8a3eeaf412f016ba19efce53936c4998c22cec39059cc4a285a9
+      - origins:
+        - local:
+            path: /tmp/build/a625eeb5/korifi
+        - git:
+            dirty: true
+            remoteURL: https://github.com/cloudfoundry/korifi.git
+            sha: c16b9dcb043598b89f2ec81b3a1c31a4673ad98f
+        - tagged:
+            tags:
+            - latest
+            - 0.16.1
+        url: index.docker.io/cloudfoundry/korifi-kpack-image-builder@sha256:95d114b48fa709667ee648162745fc3c8a8f3b008c371c70e4e6aa73b55ac863
+      - origins:
+        - local:
+            path: /tmp/build/a625eeb5/korifi
+        - git:
+            dirty: true
+            remoteURL: https://github.com/cloudfoundry/korifi.git
+            sha: c16b9dcb043598b89f2ec81b3a1c31a4673ad98f
+        - tagged:
+            tags:
+            - latest
+            - 0.16.1
+        url: index.docker.io/cloudfoundry/korifi-migration@sha256:cd3f5aef1a833e73c7d4d87ee8ce4d2c4e82fefd561d9550ae50764e8183c0d6
+      - origins:
+        - local:
+            path: /tmp/build/a625eeb5/korifi
+        - git:
+            dirty: true
+            remoteURL: https://github.com/cloudfoundry/korifi.git
+            sha: c16b9dcb043598b89f2ec81b3a1c31a4673ad98f
+        - tagged:
+            tags:
+            - latest
+            - 0.16.1
+        url: index.docker.io/cloudfoundry/korifi-statefulset-runner@sha256:bd984dcc18aa74840b6d87c81a9add5009c3d60f7b9caf6537a4881d2795356c
+migration:
+  image: index.docker.io/cloudfoundry/korifi-migration@sha256:cd3f5aef1a833e73c7d4d87ee8ce4d2c4e82fefd561d9550ae50764e8183c0d6
+  include: true
+networking:
+  gatewayClass: null
+  gatewayInfrastructure: null
+  gatewayPorts:
+    http: 80
+    https: 443
+reconcilers:
+  build: kpack-image-builder
+  run: statefulset-runner
+rootNamespace: cf
+stagingRequirements:
+  buildCacheMB: 2048
+  diskMB: 0
+  memoryMB: 0
+statefulsetRunner:
+  image: index.docker.io/cloudfoundry/korifi-statefulset-runner@sha256:bd984dcc18aa74840b6d87c81a9add5009c3d60f7b9caf6537a4881d2795356c
+  include: true
+  replicas: 1
+  resources:
+    limits:
+      cpu: 1000m
+      memory: 1Gi
+    requests:
+      cpu: 50m
+      memory: 100Mi
+  webhookCertSecret: korifi-statefulset-runner-webhook-cert
+systemImagePullSecrets: []

--- a/development/assets/Dockerfile
+++ b/development/assets/Dockerfile
@@ -7,11 +7,7 @@ FROM ${REGISTRY}/${IMG}:${VERSION} AS uploader
 ARG VERSION
 
 WORKDIR /workspace
-# Copying the korifi tgz file via a wild card would not fail if the tgz does
-# not exist. We use this trick to support either using korifi from the uploader
-# (i.e. official Korifi release), or building a local dev Korifi version. This
-# Dockerfile would only replace Korifi if the tgz below exists
-COPY release/$VERSION/korifi-${VERSION}.tgz* /workspace
+COPY release/$VERSION/korifi-${VERSION} korifi-chart
 COPY release/$VERSION/btp-service-broker btp-service-broker
 
 #--------
@@ -35,8 +31,14 @@ RUN yq -i eval '.spec.isCA = true'  module-data/certificates/certificates.tmpl
 RUN rm -rf /module-data/btp-service-broker
 COPY --from=uploader /workspace/btp-service-broker /module-data/btp-service-broker
 
-COPY --from=uploader /workspace/korifi-${VERSION}.tgz* /
-RUN test -f /korifi-${VERSION}.tgz && rm -rf /module-data/korifi/*.tgz && cp /korifi-${VERSION}.tgz /module-data/korifi/korifi-${VERSION}.tgz || echo "Using pre-packaged Korifi"
+COPY --from=uploader /workspace/korifi-chart /korifi-chart
+# If the uploader image contains a non-empty korifi directory (i.e. a local
+# build has been performed), replace the korifi helm chart with the custom
+# built one
+RUN if [ $(ls -A "/korifi-chart" | wc -l) -ne 0 ]; then \
+        echo "Korifi files found, replacing Korifi module"; \
+        rm -rf /module-data/korifi-chart/* && cp -a /korifi-chart/* /module-data/korifi-chart/; \
+    fi
 
 #--------
 FROM gcr.io/distroless/static:nonroot

--- a/development/prepare-kind.sh
+++ b/development/prepare-kind.sh
@@ -116,7 +116,7 @@ install_istio() {
   kubectl apply -f https://github.com/kyma-project/istio/releases/latest/download/istio-manager-experimental.yaml
   kubectl apply -f https://github.com/kyma-project/istio/releases/latest/download/istio-default-cr.yaml
 
-  kubectl wait --for=jsonpath='.status.state'=Ready -n kyma-system istios default
+  kubectl wait --for=jsonpath='.status.state'=Ready -n kyma-system istios default --timeout=5m
   configure_gateway_service istio-system istio-ingressgateway "$KYMA_GW_TLS_PORT"
 
   echo "************************************************"
@@ -243,12 +243,6 @@ build_local_korifi_release_chart() {
   {
     cp -a helm/korifi/* "$KORIFI_RELEASE_ARTIFACTS_DIR"
     build_korifi
-  }
-  popd
-
-  pushd "$RELEASE_OUTPUT_DIR"
-  {
-    tar czf "korifi-$VERSION.tgz" "korifi-$VERSION"
   }
   popd
 }

--- a/vendir.lock.yml
+++ b/vendir.lock.yml
@@ -13,5 +13,9 @@ directories:
       tag: v0.17.0
       url: https://api.github.com/repos/buildpacks-community/kpack/releases/213128352
     path: kpack
+  - helmChart:
+      appVersion: ""
+      version: 0.16.1
+    path: korifi
   path: dependencies
 kind: LockConfig

--- a/vendir.yml
+++ b/vendir.yml
@@ -12,7 +12,7 @@ directories:
   - path: gateway-api
     githubRelease:
       slug: kubernetes-sigs/gateway-api
-      latest: true
+      tag: v1.3.0
       disableAutoChecksumValidation: true
       assetNames: ["experimental-install.yaml"]
   - path: kpack
@@ -20,3 +20,8 @@ directories:
       slug: pivotal/kpack
       latest: true
       disableAutoChecksumValidation: true
+  - path: korifi
+    helmChart:
+      name: korifi
+      repository:
+        url: https://cloudfoundry.github.io/korifi


### PR DESCRIPTION
**Description**

* Vendor Korifi helm chart via vendir (take the opportunity to bump it to 0.16.1)
* When docker-building the operator image, we do not pull Korifi chart
  from github, instead we use the vendored chart
* Pin gateway-api to 1.3.0 as 1.4.0 contains a CRD with huge annotation
  that fail `kubectl apply`
