### PR TITLE
Helm upgrade installable noop

### DIFF
--- a/controllers/helm/client.go
+++ b/controllers/helm/client.go
@@ -3,15 +3,17 @@ package helm
 import (
 	"context"
 	"fmt"
+	"reflect"
 
 	golog "log"
 
 	"github.com/go-logr/logr"
+	"gopkg.in/yaml.v3"
 	"helm.sh/helm/v3/pkg/action"
+	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/chart/loader"
 	"helm.sh/helm/v3/pkg/cli"
 	"helm.sh/helm/v3/pkg/release"
-	"helm.sh/helm/v3/pkg/storage/driver"
 )
 
 type HelmResult struct {
@@ -28,64 +30,99 @@ func NewClient() *Client {
 func (c *Client) Apply(ctx context.Context, chartPath string, releaseNamespace string, releaseName string, values map[string]any) (HelmResult, error) {
 	log := logr.FromContextOrDiscard(ctx).WithName("helm").WithValues("chart", releaseName)
 
-	releaseExists, releaseStatus, err := releaseExists(releaseNamespace, releaseName)
-	if err != nil {
-		return HelmResult{}, fmt.Errorf("failed to check if release %s exists in namespace %s: %w", releaseName, releaseNamespace, err)
-	}
-
-	if !releaseExists {
-		return c.install(ctx, chartPath, releaseNamespace, releaseName, values)
-	}
-
-	if releaseStatus.IsPending() {
-		log.Info("helm operation is pending", "releaseStatus", releaseStatus)
-		return HelmResult{
-			ReleaseStatus: releaseStatus,
-			Message:       "operation pending",
-		}, nil
-	}
-
-	return c.upgrade(ctx, chartPath, releaseNamespace, releaseName, values)
-}
-
-func releaseExists(namespace, name string) (bool, release.Status, error) {
-	actionConfig, err := newHelmActionConfig(namespace)
-	if err != nil {
-		return false, release.StatusUnknown, fmt.Errorf("failed to init helm action config: %w", err)
-	}
-
-	histClient := action.NewHistory(actionConfig)
-	histClient.Max = 1
-	versions, err := histClient.Run(name)
-
-	if err == driver.ErrReleaseNotFound {
-		return false, release.StatusUnknown, nil
-	}
-
-	if err != nil {
-		return false, release.StatusUnknown, fmt.Errorf("failed to check helm release hustory: %w", err)
-	}
-
-	if len(versions) == 0 {
-		return false, release.StatusUnknown, nil
-	}
-
-	lastVersion := versions[len(versions)-1]
-	if lastVersion.Info.Status == release.StatusUninstalled {
-		return false, lastVersion.Info.Status, nil
-	}
-
-	return true, lastVersion.Info.Status, nil
-}
-
-func (c *Client) install(ctx context.Context, chartPath string, releaseNamespace string, releaseName string, values map[string]any) (HelmResult, error) {
-	log := logr.FromContextOrDiscard(ctx).WithName("helm-install").WithValues("chart", releaseName)
-	log.Info("starting install")
-
 	chart, err := loader.Load(chartPath)
 	if err != nil {
 		return HelmResult{}, fmt.Errorf("failed to load chart at %s: %w", chartPath, err)
 	}
+
+	latestRelease, err := getLatestReleases(releaseNamespace, releaseName)
+	if err != nil {
+		log.Error(err, "failed to get latest release")
+		return HelmResult{}, fmt.Errorf("failed to get latest release %s in namespace %s: %w", releaseName, releaseNamespace, err)
+	}
+
+	if latestRelease == nil {
+		return c.install(ctx, chart, releaseNamespace, releaseName, values)
+	}
+
+	if latestRelease.Info.Status.IsPending() {
+		log.Info("helm operation is pending", "releaseStatus", latestRelease.Info.Status)
+		return HelmResult{
+			ReleaseStatus: latestRelease.Info.Status,
+			Message:       "operation pending",
+		}, nil
+	}
+
+	equalValues, err := equalValues(latestRelease.Config, values)
+	if err != nil {
+		return HelmResult{}, fmt.Errorf("failed to compare release values: %w", err)
+	}
+	equalVersions := chart.Metadata.Version == latestRelease.Chart.Metadata.Version
+
+	if equalValues && equalVersions {
+		log.Info("helm chart does not need update")
+		return HelmResult{
+			ReleaseStatus: latestRelease.Info.Status,
+		}, nil
+	}
+
+	return c.upgrade(ctx, chart, releaseNamespace, releaseName, values)
+}
+
+func equalValues(values1, values2 map[string]any) (bool, error) {
+	v1, err := marshalUnmarshal(values1)
+	if err != nil {
+		return false, fmt.Errorf("failed to marshal-unmarshal values1: %w", err)
+	}
+	v2, err := marshalUnmarshal(values2)
+	if err != nil {
+		return false, fmt.Errorf("failed to marshal-unmarshal values2: %w", err)
+	}
+
+	return reflect.DeepEqual(v1, v2), nil
+}
+
+func marshalUnmarshal(values map[string]any) (map[string]any, error) {
+	valuesBytes, err := yaml.Marshal(values)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal values: %w", err)
+	}
+
+	valuesUnamrshalled := make(map[string]any)
+	err = yaml.Unmarshal(valuesBytes, &valuesUnamrshalled)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal values: %w", err)
+	}
+
+	return valuesUnamrshalled, nil
+}
+
+func getLatestReleases(releaseNamespace string, releaseName string) (*release.Release, error) {
+	actionConfig, err := newHelmActionConfig(releaseNamespace)
+	if err != nil {
+		return nil, fmt.Errorf("failed to init helm action config: %w", err)
+	}
+
+	listClient := action.NewList(actionConfig)
+	listClient.Sort = action.ByDateDesc
+	listClient.Limit = 1
+	listClient.Filter = releaseName
+
+	versions, err := listClient.Run()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list helm release %s%s: %w", releaseNamespace, releaseName, err)
+	}
+
+	if len(versions) == 0 {
+		return nil, nil
+	}
+
+	return versions[0], nil
+}
+
+func (c *Client) install(ctx context.Context, installedChart *chart.Chart, releaseNamespace string, releaseName string, values map[string]any) (HelmResult, error) {
+	log := logr.FromContextOrDiscard(ctx).WithName("helm-install").WithValues("chart", releaseName)
+	log.Info("starting install")
 
 	actionConfig, err := newHelmActionConfig(releaseNamespace)
 	if err != nil {
@@ -96,7 +133,7 @@ func (c *Client) install(ctx context.Context, chartPath string, releaseNamespace
 	installAction.Namespace = releaseNamespace
 	installAction.ReleaseName = releaseName
 
-	rel, err := installAction.Run(chart, values)
+	rel, err := installAction.Run(installedChart, values)
 	if err != nil {
 		return HelmResult{
 			ReleaseStatus: release.StatusUnknown,
@@ -109,14 +146,9 @@ func (c *Client) install(ctx context.Context, chartPath string, releaseNamespace
 	}, nil
 }
 
-func (c *Client) upgrade(ctx context.Context, chartPath string, releaseNamespace string, releaseName string, values map[string]any) (HelmResult, error) {
+func (c *Client) upgrade(ctx context.Context, upgradedChart *chart.Chart, releaseNamespace string, releaseName string, values map[string]any) (HelmResult, error) {
 	log := logr.FromContextOrDiscard(ctx).WithName("helm-upgrade").WithValues("chart", releaseName)
 	log.Info("starting upgrade")
-
-	chart, err := loader.Load(chartPath)
-	if err != nil {
-		return HelmResult{}, fmt.Errorf("failed to load chart at %s: %w", chartPath, err)
-	}
 
 	actionConfig, err := newHelmActionConfig(releaseNamespace)
 	if err != nil {
@@ -127,7 +159,7 @@ func (c *Client) upgrade(ctx context.Context, chartPath string, releaseNamespace
 	upgradeAction.Namespace = releaseNamespace
 	upgradeAction.Install = true
 
-	rel, err := upgradeAction.Run(releaseName, chart, values)
+	rel, err := upgradeAction.Run(releaseName, upgradedChart, values)
 	if err != nil {
 		return HelmResult{
 			ReleaseStatus: release.StatusUnknown,

--- a/tests/assets/dummy-chart-v2/Chart.yaml
+++ b/tests/assets/dummy-chart-v2/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: dummy-chart
+description: A Dummy helm chart
+type: application
+version: 0.0.2

--- a/tests/assets/dummy-chart-v2/configmaps/configmap.yaml
+++ b/tests/assets/dummy-chart-v2/configmaps/configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dummy-configmap-v2
+  namespace: {{ .Release.Namespace }}
+data:
+  helm-value: {{ .Values.configMapValue }}
+  secret-values: {{ include "dummy.secret" . }}
+  v2-key: v2-value

--- a/tests/assets/dummy-chart-v2/templates/_helpers.yaml
+++ b/tests/assets/dummy-chart-v2/templates/_helpers.yaml
@@ -1,0 +1,5 @@
+{{- define "dummy.secret" -}}
+{{- $caBundle := "" -}}
+{{- $caBundle = index (lookup "v1" "Secret" .Release.Namespace "dummy-secret").data "my-secret-key" | b64dec -}}
+{{ $caBundle }}
+{{- end -}}

--- a/tests/assets/dummy-chart-v2/templates/components.yaml
+++ b/tests/assets/dummy-chart-v2/templates/components.yaml
@@ -1,0 +1,5 @@
+{{- $ctx := . }}
+{{- range $path, $_ := .Files.Glob "configmaps/*.yaml" }}
+---
+{{ tpl ($.Files.Get $path) $ctx }}
+{{- end }}

--- a/tests/assets/dummy-chart-v2/values.yaml
+++ b/tests/assets/dummy-chart-v2/values.yaml
@@ -1,0 +1,2 @@
+---
+configMapValue: dummy-value

--- a/tests/integration/helm/helm_test.go
+++ b/tests/integration/helm/helm_test.go
@@ -3,6 +3,10 @@ package helm_test
 import (
 	"context"
 	"errors"
+	"fmt"
+	"time"
+
+	golog "log"
 
 	"github.com/kyma-project/cfapi/api/v1alpha1"
 	"github.com/kyma-project/cfapi/controllers/helm"
@@ -10,7 +14,12 @@ import (
 	"github.com/kyma-project/cfapi/tests/integration/helm/fake"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"helm.sh/helm/v3/pkg/action"
+	"helm.sh/helm/v3/pkg/cli"
+	"helm.sh/helm/v3/pkg/release"
+	"helm.sh/helm/v3/pkg/storage/driver"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -49,9 +58,12 @@ var _ = Describe("HelmChartInstallableIntegrationTest", func() {
 
 	It("applies the chart", func() {
 		Expect(installErr).NotTo(HaveOccurred())
-		Expect(result.State).To(Equal(installable.ResultStateSuccess))
 
 		Eventually(func(g Gomega) {
+			installedReleases := listReleases("dummy-chart")
+			g.Expect(installedReleases).To(HaveLen(1))
+			g.Expect(installedReleases[0].Info.Status).To(Equal(release.StatusDeployed))
+
 			configMap := &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: testNamespace,
@@ -74,7 +86,13 @@ var _ = Describe("HelmChartInstallableIntegrationTest", func() {
 		It("it returns inprogress result", func() {
 			Expect(installErr).NotTo(HaveOccurred())
 			Expect(result.State).To(Equal(installable.ResultStateInProgress))
-			Expect(result.Message).To(ContainSubstring("status unknown"))
+			Expect(result.Message).To(SatisfyAll(ContainSubstring("status unknown"), ContainSubstring("lookup")))
+		})
+
+		It("does not deploy the chart (as helm templating fails)", func() {
+			Consistently(func(g Gomega) {
+				g.Expect(listReleases("dummy-chart")).To(BeEmpty())
+			}).Should(Succeed())
 		})
 	})
 
@@ -86,10 +104,11 @@ var _ = Describe("HelmChartInstallableIntegrationTest", func() {
 		})
 
 		It("uses them when applying the chart", func() {
-			Expect(installErr).NotTo(HaveOccurred())
-			Expect(result.State).To(Equal(installable.ResultStateSuccess))
-
 			Eventually(func(g Gomega) {
+				installedReleases := listReleases("dummy-chart")
+				g.Expect(installedReleases).To(HaveLen(1))
+				g.Expect(installedReleases[0].Info.Status).To(Equal(release.StatusDeployed))
+
 				configMap := &corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: testNamespace,
@@ -129,18 +148,11 @@ var _ = Describe("HelmChartInstallableIntegrationTest", func() {
 	When("the chart is already installed", func() {
 		JustBeforeEach(func() {
 			Expect(installErr).NotTo(HaveOccurred())
-			Expect(result.State).To(Equal(installable.ResultStateSuccess))
 
 			Eventually(func(g Gomega) {
-				Eventually(func(g Gomega) {
-					configMap := &corev1.ConfigMap{
-						ObjectMeta: metav1.ObjectMeta{
-							Namespace: testNamespace,
-							Name:      "dummy-configmap",
-						},
-					}
-					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(configMap), configMap)).To(Succeed())
-				}).Should(Succeed())
+				installedReleases := listReleases("dummy-chart")
+				g.Expect(installedReleases).To(HaveLen(1))
+				g.Expect(installedReleases[0].Info.Status).To(Equal(release.StatusDeployed))
 			}).Should(Succeed())
 		})
 
@@ -153,27 +165,18 @@ var _ = Describe("HelmChartInstallableIntegrationTest", func() {
 				Expect(installErr).NotTo(HaveOccurred())
 				Expect(result.State).To(Equal(installable.ResultStateSuccess))
 
-				Eventually(func(g Gomega) {
-					configMap := &corev1.ConfigMap{
-						ObjectMeta: metav1.ObjectMeta{
-							Namespace: testNamespace,
-							Name:      "dummy-configmap",
-						},
-					}
-					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(configMap), configMap)).To(Succeed())
-					g.Expect(configMap.Data).To(Equal(map[string]string{
-						"helm-value":    "dummy-value",
-						"secret-values": "my-secret-value",
-					}))
-				}).Should(Succeed())
+				installedReleases := listReleases("dummy-chart")
+				Expect(installedReleases).To(HaveLen(1))
+				Expect(installedReleases[0].Info.Status).To(Equal(release.StatusDeployed))
 			})
 		})
 
-		When("helm values change", func() {
+		When("reinstalling the chart with new values", func() {
 			JustBeforeEach(func() {
 				valuesProvider.GetValuesReturns(map[string]any{
 					"configMapValue": "my-very-custom-value",
 				}, nil)
+				time.Sleep(time.Second)
 				result, installErr = helmChartInstaller.Install(context.Background(), v1alpha1.InstallationConfig{}, new(fake.EventRecorder))
 			})
 
@@ -182,6 +185,11 @@ var _ = Describe("HelmChartInstallableIntegrationTest", func() {
 				Expect(result.State).To(Equal(installable.ResultStateSuccess))
 
 				Eventually(func(g Gomega) {
+					installedReleases := listReleases("dummy-chart")
+					g.Expect(installedReleases).To(HaveLen(2))
+					g.Expect(installedReleases[0].Info.Status).To(Equal(release.StatusSuperseded))
+					g.Expect(installedReleases[1].Info.Status).To(Equal(release.StatusDeployed))
+
 					configMap := &corev1.ConfigMap{
 						ObjectMeta: metav1.ObjectMeta{
 							Namespace: testNamespace,
@@ -193,5 +201,68 @@ var _ = Describe("HelmChartInstallableIntegrationTest", func() {
 				}).Should(Succeed())
 			})
 		})
+
+		When("upgrading to a newer chart version", func() {
+			JustBeforeEach(func() {
+				helmChartInstaller = installable.NewHelmChart("../../assets/dummy-chart-v2", testNamespace, "dummy-chart", valuesProvider, helm.NewClient())
+				result, installErr = helmChartInstaller.Install(context.Background(), v1alpha1.InstallationConfig{}, new(fake.EventRecorder))
+			})
+
+			It("upgrades to the new helm version", func() {
+				Expect(installErr).NotTo(HaveOccurred())
+				Expect(result).To(Equal(installable.Result{}))
+
+				Eventually(func(g Gomega) {
+					installedReleases := listReleases("dummy-chart")
+					g.Expect(installedReleases).To(HaveLen(2))
+					g.Expect(installedReleases[0].Info.Status).To(Equal(release.StatusSuperseded))
+					g.Expect(installedReleases[1].Info.Status).To(Equal(release.StatusDeployed))
+
+					oldConfigMap := &corev1.ConfigMap{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: testNamespace,
+							Name:      "dummy-configmap",
+						},
+					}
+					g.Expect(apierrors.IsNotFound(k8sClient.Get(ctx, client.ObjectKeyFromObject(oldConfigMap), oldConfigMap))).To(BeTrue())
+
+					newConfigMap := &corev1.ConfigMap{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: testNamespace,
+							Name:      "dummy-configmap-v2",
+						},
+					}
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(newConfigMap), newConfigMap)).To(Succeed())
+					g.Expect(newConfigMap.Data).To(HaveKeyWithValue("v2-key", "v2-value"))
+				}).Should(Succeed())
+			})
+		})
 	})
 })
+
+func listReleases(releaseName string) []*release.Release {
+	actionConfig, err := newHelmActionConfig(testNamespace)
+	Expect(err).NotTo(HaveOccurred())
+
+	historyClient := action.NewHistory(actionConfig)
+	versions, err := historyClient.Run(releaseName)
+	if err != nil {
+		if err == driver.ErrReleaseNotFound {
+			return nil
+		}
+		Expect(err).NotTo(HaveOccurred())
+	}
+
+	return versions
+}
+
+func newHelmActionConfig(releaseNamespace string) (*action.Configuration, error) {
+	helmSettings := cli.New()
+	actionConfig := new(action.Configuration)
+	err := actionConfig.Init(helmSettings.RESTClientGetter(), releaseNamespace, "secret", golog.Printf)
+	if err != nil {
+		return nil, fmt.Errorf("failed to init helm action config: %w", err)
+	}
+
+	return actionConfig, nil
+}


### PR DESCRIPTION
**Description**

Currently helm installable make plenty of upgrades during reconcilation which causes the korifi jobs pods to restart many times.
This is fixed by cheking if values which we want to apply the chart are different or the version of the chart, only
then upgrade is performed

