### PR TITLE
Enable dependabot go bumps for `components/btp-service-broker`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,15 @@ updates:
       patterns:
         - "*"
 
+- package-ecosystem: "gomod"
+  directory: "/components/btp-service-broker"
+  schedule:
+    interval: "daily"
+  groups:
+    gomod:
+      patterns:
+        - "*"
+
 - package-ecosystem: "docker"
   directory: "/"
   schedule:


### PR DESCRIPTION
Enable dependabot go bumps for `components/btp-service-broker`